### PR TITLE
test: restore library crate imports for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ homepage = "https://github.com/anthonyamaro15/file-finder-rust"
 description = "A blazing-fast TUI file finder with fuzzy search, ranking, and IDE integration"
 license = "MIT"
 
+[lib]
+name = "file_finder"
+path = "src/lib.rs"
+
 [dependencies]
 anyhow = "1.0.83"
 clap = { version = "4.0", features = ["derive"] }
@@ -82,4 +86,3 @@ dist = true
 [[bin]]
 name = "ff"
 path = "src/main.rs"
-

--- a/src/app.rs
+++ b/src/app.rs
@@ -581,6 +581,15 @@ impl App {
         new_cursor_pos.clamp(0, self.create_edit_file_name.chars().count())
     }
 
+    pub fn validate_user_input(&self, input: &str) -> Option<IDE> {
+        match input {
+            "nvim" => Some(IDE::NVIM),
+            "vscode" => Some(IDE::VSCODE),
+            "zed" => Some(IDE::ZED),
+            _ => None,
+        }
+    }
+
     pub fn get_selected_ide(&self) -> Option<String> {
         if let Some(selection) = &self.selected_id {
             match selection {
@@ -1019,5 +1028,4 @@ impl App {
         self.preview_pending_since = None;
     }
 }
-
 


### PR DESCRIPTION
## Summary
- add an explicit lib crate name so integration tests/examples can import `file_finder` while the binary remains `ff`
- restore `App::validate_user_input` for supported editor names used by existing tests

## Verification
- `cargo check --all-targets --quiet` passes
- `cargo test --test app_tests --quiet` passes: 28 passed
- `cargo test --quiet` still fails on the known watcher test: `watcher::tests::test_file_creation_detection`

