### PR TITLE
test: assert production behavior in integration tests

### DIFF
--- a/tests/file_operations_tests.rs
+++ b/tests/file_operations_tests.rs
@@ -1,5 +1,11 @@
 mod common;
 
+use file_finder::app::App;
+use file_finder::operations::file_ops::{create_new_dir, create_new_file, delete_dir, delete_file};
+use file_finder::operations::{
+    copy_dir_file_helper, create_item_based_on_type, handle_delete_based_on_type, handle_rename,
+};
+use file_finder::utils::files::{check_if_exists, generate_copy_file_dir_name};
 use std::fs;
 use std::path::Path;
 use tempfile::tempdir;
@@ -7,33 +13,6 @@ use tempfile::tempdir;
 #[cfg(test)]
 mod file_creation_tests {
     use super::*;
-
-    fn create_new_file(current_file_path: String, file_name: String) -> anyhow::Result<()> {
-        let append_path = format!("{}/{}", current_file_path, file_name);
-        match fs::File::create_new(append_path) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e.into()),
-        }
-    }
-
-    fn create_new_dir(current_file_path: String, new_item: String) -> anyhow::Result<()> {
-        let append_path = format!("{}/{}", current_file_path, new_item);
-        match fs::create_dir(append_path) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e.into()),
-        }
-    }
-
-    fn create_item_based_on_type(
-        current_file_path: String,
-        new_item: String,
-    ) -> anyhow::Result<()> {
-        if new_item.contains(".") {
-            create_new_file(current_file_path, new_item)
-        } else {
-            create_new_dir(current_file_path, new_item)
-        }
-    }
 
     #[test]
     fn test_create_new_file_success() {
@@ -119,32 +98,6 @@ mod file_creation_tests {
 #[cfg(test)]
 mod file_deletion_tests {
     use super::*;
-
-    fn delete_file(file: &str) -> anyhow::Result<()> {
-        match fs::remove_file(file) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e.into()),
-        }
-    }
-
-    fn delete_dir(file: &str) -> anyhow::Result<()> {
-        match fs::remove_dir_all(file) {
-            Ok(_) => Ok(()),
-            Err(e) => Err(e.into()),
-        }
-    }
-
-    fn handle_delete_based_on_type(file: &str) -> anyhow::Result<()> {
-        let metadata = fs::metadata(file)?;
-        let file_type = metadata.file_type();
-
-        if file_type.is_dir() {
-            delete_dir(file)?;
-        } else {
-            delete_file(file)?;
-        }
-        Ok(())
-    }
 
     #[test]
     fn test_delete_file_success() {
@@ -234,16 +187,13 @@ mod file_deletion_tests {
 #[cfg(test)]
 mod file_rename_tests {
     use super::*;
-    use std::io;
 
-    fn handle_rename(old_path: String, new_name: String, current_dir: String) -> io::Result<()> {
-        let curr_path = format!("{}/{}", current_dir, old_path);
-        let new_path = format!("{}/{}", current_dir, new_name);
-
-        match fs::rename(curr_path, new_path) {
-            Ok(res) => Ok(res),
-            Err(error) => Err(error),
-        }
+    fn rename_app(current_dir: String, current_name: &str, new_name: &str) -> App {
+        let mut app = App::new(Vec::new());
+        app.current_path_to_edit = current_dir;
+        app.current_name_to_edit = current_name.to_string();
+        app.create_edit_file_name = new_name.to_string();
+        app
     }
 
     #[test]
@@ -259,11 +209,8 @@ mod file_rename_tests {
         fs::write(temp_dir.path().join(old_name), file_content)
             .expect("Failed to create test file");
 
-        let result = handle_rename(
-            old_name.to_string(),
-            new_name.to_string(),
-            temp_path.clone(),
-        );
+        let app = rename_app(temp_path.clone(), old_name, new_name);
+        let result = handle_rename(&app);
 
         assert!(result.is_ok());
         assert!(!Path::new(&format!("{}/{}", temp_path, old_name)).exists());
@@ -289,11 +236,8 @@ mod file_rename_tests {
         fs::write(old_dir_path.join("file.txt"), "content")
             .expect("Failed to create file in directory");
 
-        let result = handle_rename(
-            old_name.to_string(),
-            new_name.to_string(),
-            temp_path.clone(),
-        );
+        let app = rename_app(temp_path.clone(), old_name, new_name);
+        let result = handle_rename(&app);
 
         assert!(result.is_ok());
         assert!(!Path::new(&format!("{}/{}", temp_path, old_name)).exists());
@@ -313,7 +257,8 @@ mod file_rename_tests {
         let old_name = "nonexistent.txt";
         let new_name = "new_file.txt";
 
-        let result = handle_rename(old_name.to_string(), new_name.to_string(), temp_path);
+        let app = rename_app(temp_path, old_name, new_name);
+        let result = handle_rename(&app);
 
         assert!(result.is_err());
     }
@@ -332,57 +277,18 @@ mod file_rename_tests {
         fs::write(temp_dir.path().join(new_name), "target content")
             .expect("Failed to create target file");
 
-        let result = handle_rename(old_name.to_string(), new_name.to_string(), temp_path);
+        let app = rename_app(temp_path.clone(), old_name, new_name);
+        let result = handle_rename(&app);
 
-        // On most systems, rename should succeed and overwrite the target
-        // But we'll check that one of them doesn't exist anymore
-        assert!(result.is_ok());
+        assert!(result.is_err());
+        assert!(Path::new(&format!("{}/{}", temp_path, old_name)).exists());
+        assert!(Path::new(&format!("{}/{}", temp_path, new_name)).exists());
     }
 }
 
 #[cfg(test)]
 mod file_copy_tests {
     use super::*;
-    use rayon::prelude::*;
-    use std::io::{self, ErrorKind};
-    use walkdir::WalkDir;
-
-    fn copy_dir_file_helper(src: &Path, new_src: &Path) -> anyhow::Result<()> {
-        if src.is_file() {
-            fs::copy(src, new_src)?;
-        } else {
-            let entries: Vec<_> = WalkDir::new(src)
-                .into_iter()
-                .filter_map(Result::ok)
-                .collect();
-            entries.par_iter().try_for_each(|entry| {
-                let entry_path = entry.path();
-                let relative_path = entry_path.strip_prefix(src).unwrap();
-                let dst_path = new_src.join(relative_path);
-
-                if entry_path.is_dir() {
-                    fs::create_dir_all(&dst_path)?;
-                } else if entry_path.is_file() {
-                    if let Some(parent) = dst_path.parent() {
-                        fs::create_dir_all(parent)?;
-                    }
-                    fs::copy(entry_path, dst_path)?;
-                } else {
-                    return Err(io::Error::new(ErrorKind::Other, "unsupported file type"));
-                }
-
-                Ok(())
-            })?;
-        }
-
-        Ok(())
-    }
-
-    fn generate_copy_file_dir_name(curr_path: String, new_path: String) -> String {
-        let get_info = Path::new(&curr_path);
-        let file_name = get_info.file_name().unwrap().to_str().unwrap();
-        format!("{}/copy_{}", new_path, file_name)
-    }
 
     #[test]
     fn test_copy_file_success() {
@@ -479,13 +385,6 @@ mod file_copy_tests {
 #[cfg(test)]
 mod path_validation_tests {
     use super::*;
-
-    fn check_if_exists(new_path: String) -> bool {
-        match Path::new(&new_path).try_exists() {
-            Ok(value) => value,
-            Err(_) => false,
-        }
-    }
 
     #[test]
     fn test_check_if_exists_file() {

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -1,104 +1,22 @@
 mod common;
 
 use common::*;
+use file_finder::utils::files::{
+    convert_file_path_to_string, generate_copy_file_dir_name, get_curr_path, is_file,
+    sort_entries_by_type, SortBy, SortType,
+};
 use std::fs;
-use std::path::PathBuf;
-use tempfile::tempdir;
-
-// We need to make the functions in main.rs accessible for testing
-// For now, I'll test the logic by creating similar functions
 
 #[cfg(test)]
 mod sorting_tests {
     use super::*;
-
-    #[derive(Clone)]
-    pub enum SortType {
-        ASC,
-        DESC,
-    }
-
-    #[derive(Clone)]
-    pub enum SortBy {
-        Name,
-        Size,
-        DateAdded,
-        Default,
-    }
-
-    // Replicate the sorting function for testing
-    fn sort_entries_by_type(
-        sort_by: SortBy,
-        sort_type: SortType,
-        mut entries: Vec<PathBuf>,
-    ) -> Vec<PathBuf> {
-        match sort_type {
-            SortType::ASC => match sort_by {
-                SortBy::Name => entries.sort_by(|a, b| {
-                    a.file_name()
-                        .unwrap()
-                        .to_ascii_lowercase()
-                        .cmp(&b.file_name().unwrap().to_ascii_lowercase())
-                }),
-                SortBy::Size => entries.sort_by(|a, b| {
-                    a.metadata()
-                        .ok()
-                        .map(|meta| meta.len())
-                        .unwrap_or(0)
-                        .cmp(&b.metadata().ok().map(|meta| meta.len()).unwrap_or(0))
-                }),
-                SortBy::DateAdded => entries.sort_by(|a, b| {
-                    a.metadata()
-                        .ok()
-                        .and_then(|meta| meta.created().ok())
-                        .unwrap_or(std::time::SystemTime::now())
-                        .cmp(
-                            &b.metadata()
-                                .ok()
-                                .and_then(|meta| meta.created().ok())
-                                .unwrap_or(std::time::SystemTime::now()),
-                        )
-                }),
-                _ => {}
-            },
-            SortType::DESC => match sort_by {
-                SortBy::Name => entries.sort_by(|a, b| {
-                    b.file_name()
-                        .unwrap()
-                        .to_ascii_lowercase()
-                        .cmp(&a.file_name().unwrap().to_ascii_lowercase())
-                }),
-                SortBy::Size => entries.sort_by(|a, b| {
-                    b.metadata()
-                        .ok()
-                        .map(|meta| meta.len())
-                        .unwrap_or(0)
-                        .cmp(&a.metadata().ok().map(|meta| meta.len()).unwrap_or(0))
-                }),
-                SortBy::DateAdded => entries.sort_by(|a, b| {
-                    b.metadata()
-                        .ok()
-                        .and_then(|meta| meta.created().ok())
-                        .unwrap_or(std::time::SystemTime::now())
-                        .cmp(
-                            &a.metadata()
-                                .ok()
-                                .and_then(|meta| meta.created().ok())
-                                .unwrap_or(std::time::SystemTime::now()),
-                        )
-                }),
-                _ => {}
-            },
-        }
-        entries
-    }
 
     #[test]
     fn test_sort_by_name_ascending() {
         let temp_dir = setup_simple_test_directory().expect("Failed to create test directory");
         let base_path = temp_dir.path();
 
-        let mut entries = vec![
+        let entries = vec![
             base_path.join("zebra.txt"),
             base_path.join("apple.txt"),
             base_path.join("banana.txt"),
@@ -130,7 +48,7 @@ mod sorting_tests {
         let temp_dir = setup_simple_test_directory().expect("Failed to create test directory");
         let base_path = temp_dir.path();
 
-        let mut entries = vec![
+        let entries = vec![
             base_path.join("apple.txt"),
             base_path.join("zebra.txt"),
             base_path.join("banana.txt"),
@@ -217,23 +135,6 @@ mod sorting_tests {
 mod path_handling_tests {
     use super::*;
 
-    fn get_curr_path(path: String) -> String {
-        let mut split_path = path.split("/").collect::<Vec<&str>>();
-        split_path.pop();
-        let vec_to_str = split_path.join("/");
-        vec_to_str
-    }
-
-    fn is_file(path: String) -> bool {
-        match fs::metadata(path) {
-            Ok(file) => {
-                let file_t = file.file_type();
-                file_t.is_file()
-            }
-            Err(_) => false,
-        }
-    }
-
     #[test]
     fn test_get_curr_path() {
         let path = "/home/user/documents/file.txt".to_string();
@@ -274,32 +175,7 @@ mod path_handling_tests {
 
 #[cfg(test)]
 mod string_conversion_tests {
-    use super::sorting_tests::{SortBy, SortType};
     use super::*;
-
-    fn convert_file_path_to_string(
-        entries: Vec<PathBuf>,
-        show_hidden: bool,
-        _sort_by: SortBy,
-        _sort_type: SortType,
-    ) -> Vec<String> {
-        let mut file_strings: Vec<String> = Vec::new();
-
-        for entry in entries {
-            if entry.is_dir() {
-                let file = entry.into_os_string().to_str().unwrap().to_string();
-                file_strings.push(file);
-            } else if entry.is_file() {
-                let file_name = entry.file_name().unwrap().to_str().unwrap();
-                if show_hidden || !file_name.starts_with(".") {
-                    let entry_value = entry.to_str().unwrap().to_string();
-                    file_strings.push(entry_value);
-                }
-            }
-        }
-
-        file_strings
-    }
 
     #[test]
     fn test_convert_paths_show_all() {
@@ -342,25 +218,6 @@ mod string_conversion_tests {
 mod utility_tests {
     use super::*;
 
-    fn generate_copy_file_dir_name(curr_path: String, new_path: String) -> String {
-        let get_info = std::path::Path::new(&curr_path);
-        let file_name = get_info.file_name().unwrap().to_str().unwrap();
-        format!("{}/copy_{}", new_path, file_name)
-    }
-
-    fn create_item_based_on_type(
-        current_file_path: String,
-        new_item: String,
-    ) -> Result<bool, Box<dyn std::error::Error>> {
-        if new_item.contains(".") {
-            // It's a file
-            Ok(true)
-        } else {
-            // It's a directory
-            Ok(false)
-        }
-    }
-
     #[test]
     fn test_generate_copy_file_dir_name() {
         let curr_path = "/home/user/document.txt".to_string();
@@ -368,23 +225,5 @@ mod utility_tests {
 
         let result = generate_copy_file_dir_name(curr_path, new_path);
         assert_eq!(result, "/home/user/backup/copy_document.txt");
-    }
-
-    #[test]
-    fn test_create_item_based_on_type_file() {
-        let current_path = "/tmp".to_string();
-        let new_item = "test.txt".to_string();
-
-        let result = create_item_based_on_type(current_path, new_item).unwrap();
-        assert!(result); // Should be true for files
-    }
-
-    #[test]
-    fn test_create_item_based_on_type_directory() {
-        let current_path = "/tmp".to_string();
-        let new_item = "new_directory".to_string();
-
-        let result = create_item_based_on_type(current_path, new_item).unwrap();
-        assert!(!result); // Should be false for directories
     }
 }


### PR DESCRIPTION
## Summary
- Replace duplicated test-only helper logic with production APIs in unit and file operation integration tests.
- Update rename collision coverage to assert production behavior without overwriting an existing target.
- Remove low-signal create-item tests that only exercised a fake boolean helper.

## Test Plan
- [x] rustfmt --check tests/unit_tests.rs tests/file_operations_tests.rs
- [x] cargo test --quiet