### PR TITLE
ci: add test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: test
+    runs-on: macos-14
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Check all targets
+        run: cargo check --all-targets --quiet
+
+      - name: Test
+        run: cargo test --quiet


### PR DESCRIPTION
## Summary
- Add a CI workflow for pushes to main and all pull requests.
- Install stable Rust, cache cargo artifacts, and run the baseline compile/test commands.
- Use macos-14 to match the current development and filesystem-test environment.

## Test Plan
- [x] cargo check --all-targets --quiet
- [x] cargo test --quiet