### PR TITLE
refactor: keyboard handling helpers

### DIFF
--- a/src/event/file_actions.rs
+++ b/src/event/file_actions.rs
@@ -1,6 +1,10 @@
 use std::path::{Path, PathBuf};
 
-use crate::event::navigation::parent_directory;
+use crate::{
+    app::App,
+    event::navigation::parent_directory,
+    utils::get_file_path_data,
+};
 
 pub fn containing_directory(path: &Path) -> PathBuf {
     parent_directory(path).unwrap_or_default()
@@ -25,9 +29,27 @@ pub fn rename_target(path: &Path) -> Option<(PathBuf, String)> {
     Some((parent, name))
 }
 
+pub fn refresh_file_list(app: &mut App, directory: &Path) -> anyhow::Result<()> {
+    let file_path_list = get_file_path_data(
+        directory.to_string_lossy().to_string(),
+        app.show_hidden_files,
+        app.sort_by.clone(),
+        &app.sort_type,
+    )?;
+
+    app.files = file_path_list.clone();
+    app.read_only_files = file_path_list;
+    app.update_file_references();
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+
+    use crate::utils::{SortBy, SortType};
 
     #[test]
     fn containing_directory_returns_parent_path() {
@@ -48,5 +70,33 @@ mod tests {
     #[test]
     fn containing_directory_or_current_falls_back_to_current_directory() {
         assert_eq!(containing_directory_or_current(Path::new("/")), PathBuf::from("."));
+    }
+
+    #[test]
+    fn refresh_file_list_preserves_current_sort_preferences() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        fs::write(temp_dir.path().join("apple.txt"), "small").expect("write apple");
+        fs::write(temp_dir.path().join("zebra.txt"), "larger content").expect("write zebra");
+
+        let mut app = App::new(Vec::new());
+        app.sort_by = SortBy::Name;
+        app.sort_type = SortType::DESC;
+
+        refresh_file_list(&mut app, temp_dir.path()).expect("refresh");
+
+        let names = app
+            .files
+            .iter()
+            .map(|path| {
+                Path::new(path)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap()
+                    .to_string()
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["zebra.txt", "apple.txt"]);
+        assert_eq!(app.read_only_files, app.files);
     }
 }

--- a/src/event/file_actions.rs
+++ b/src/event/file_actions.rs
@@ -1,0 +1,52 @@
+use std::path::{Path, PathBuf};
+
+use crate::event::navigation::parent_directory;
+
+pub fn containing_directory(path: &Path) -> PathBuf {
+    parent_directory(path).unwrap_or_default()
+}
+
+pub fn containing_directory_or_current(path: &Path) -> PathBuf {
+    parent_directory(path).unwrap_or_else(|| PathBuf::from("."))
+}
+
+pub fn create_target_directory(selected: &Path) -> PathBuf {
+    if selected.is_dir() {
+        selected.to_path_buf()
+    } else {
+        containing_directory(selected)
+    }
+}
+
+pub fn rename_target(path: &Path) -> Option<(PathBuf, String)> {
+    let parent = containing_directory(path);
+    let name = path.file_name()?.to_str()?.to_string();
+
+    Some((parent, name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn containing_directory_returns_parent_path() {
+        assert_eq!(
+            containing_directory(Path::new("/tmp/example/file.txt")),
+            PathBuf::from("/tmp/example")
+        );
+    }
+
+    #[test]
+    fn rename_target_returns_parent_and_file_name() {
+        assert_eq!(
+            rename_target(Path::new("/tmp/example/file.txt")),
+            Some((PathBuf::from("/tmp/example"), "file.txt".to_string()))
+        );
+    }
+
+    #[test]
+    fn containing_directory_or_current_falls_back_to_current_directory() {
+        assert_eq!(containing_directory_or_current(Path::new("/")), PathBuf::from("."));
+    }
+}

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -1,0 +1,4 @@
+pub mod file_actions;
+pub mod navigation;
+pub mod search;
+pub mod sort;

--- a/src/event/navigation.rs
+++ b/src/event/navigation.rs
@@ -1,0 +1,79 @@
+use std::path::{Path, PathBuf};
+
+pub fn parent_directory(path: &Path) -> Option<PathBuf> {
+    path.parent().map(Path::to_path_buf)
+}
+
+pub fn next_index(current: Option<usize>, len: usize) -> Option<usize> {
+    if len == 0 {
+        None
+    } else {
+        Some(current.map(|i| (i + 1).min(len - 1)).unwrap_or(0))
+    }
+}
+
+pub fn previous_index(current: Option<usize>, len: usize) -> Option<usize> {
+    if len == 0 {
+        None
+    } else {
+        Some(current.map(|i| i.saturating_sub(1)).unwrap_or(0))
+    }
+}
+
+pub fn next_index_wrapping(current: Option<usize>, len: usize) -> Option<usize> {
+    if len == 0 {
+        None
+    } else if current == Some(len - 1) {
+        Some(0)
+    } else {
+        next_index(current, len)
+    }
+}
+
+pub fn previous_index_wrapping(current: Option<usize>, len: usize) -> Option<usize> {
+    if len == 0 {
+        None
+    } else if current == Some(0) {
+        Some(len - 1)
+    } else {
+        previous_index(current, len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn next_index_returns_none_for_empty_list() {
+        assert_eq!(next_index(Some(0), 0), None);
+    }
+
+    #[test]
+    fn next_index_stops_at_last_item() {
+        assert_eq!(next_index(Some(2), 3), Some(2));
+    }
+
+    #[test]
+    fn previous_index_stops_at_zero() {
+        assert_eq!(previous_index(Some(0), 3), Some(0));
+    }
+
+    #[test]
+    fn parent_directory_returns_parent_path() {
+        assert_eq!(
+            parent_directory(Path::new("/tmp/example/file.txt")),
+            Some(PathBuf::from("/tmp/example"))
+        );
+    }
+
+    #[test]
+    fn next_index_wrapping_wraps_to_start() {
+        assert_eq!(next_index_wrapping(Some(2), 3), Some(0));
+    }
+
+    #[test]
+    fn previous_index_wrapping_wraps_to_end() {
+        assert_eq!(previous_index_wrapping(Some(0), 3), Some(2));
+    }
+}

--- a/src/event/search.rs
+++ b/src/event/search.rs
@@ -1,0 +1,28 @@
+use crossterm::event::KeyCode;
+
+use crate::{
+    app::{App, InputMode},
+    directory_store::DirectoryStore,
+};
+
+pub fn handle_search_key(app: &mut App, key_code: KeyCode, store: &DirectoryStore) {
+    match key_code {
+        KeyCode::Enter => app.submit_message(),
+        KeyCode::Char(to_insert) => {
+            app.enter_char(to_insert, store.clone());
+        }
+        KeyCode::Backspace => {
+            app.delete_char(store.clone());
+        }
+        KeyCode::Left => {
+            app.move_cursor_left();
+        }
+        KeyCode::Right => {
+            app.move_cursor_right();
+        }
+        KeyCode::Esc => {
+            app.input_mode = InputMode::Normal;
+        }
+        _ => {}
+    }
+}

--- a/src/event/sort.rs
+++ b/src/event/sort.rs
@@ -1,0 +1,28 @@
+use crate::{
+    app::{App, InputMode},
+    utils::{get_curr_path, get_file_path_data, SortBy},
+};
+
+/// Apply a sort operation to the current file list and persist the preference.
+pub fn apply_sort(app: &mut App, sort_by: SortBy) -> anyhow::Result<()> {
+    if app.files.is_empty() {
+        return Ok(());
+    }
+
+    app.sort_by = sort_by.clone();
+
+    let cur_path = get_curr_path(app.files[0].clone());
+    let file_path_list = get_file_path_data(
+        cur_path,
+        app.show_hidden_files,
+        app.sort_by.clone(),
+        &app.sort_type,
+    )?;
+
+    app.files = file_path_list.clone();
+    app.read_only_files = file_path_list;
+    app.update_file_references();
+    app.input_mode = InputMode::Normal;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod configuration;
 pub mod directory_store;
 pub mod errors;
+pub mod event;
 pub mod file_reader_content;
 pub mod highlight;
 pub mod icons;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::{
 // External crate imports
 use copypasta::{ClipboardContext, ClipboardProvider};
 use crossterm::{
-    event::{self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
+    event::{self as crossterm_event, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -37,6 +37,7 @@ mod config;
 mod configuration;
 mod directory_store;
 mod errors;
+mod event;
 mod file_reader_content;
 mod highlight;
 mod operations;
@@ -54,6 +55,15 @@ use crate::{
     app::{App, InputMode, PanePosition, ViewMode},
     cli::{compute_effective_config, CliArgs},
     directory_store::{build_directory_from_store_async, load_directory_from_file, DirectoryStore},
+    event::{
+        file_actions::{
+            containing_directory, containing_directory_or_current, create_target_directory,
+            rename_target,
+        },
+        navigation::{next_index_wrapping, parent_directory, previous_index_wrapping},
+        search::handle_search_key,
+        sort::apply_sort,
+    },
     file_reader_content::{FileContent, FileType},
     operations::{
         copy_dir_file_with_progress, create_item_based_on_type, delete_with_progress,
@@ -366,32 +376,6 @@ fn update_preview_for_path(
 
         app.preview_files = Vec::new();
     }
-}
-
-/// Apply a sort operation to the current file list.
-/// This consolidates the duplicated sort logic from the WatchSort handlers.
-/// Also persists the sort state to app for future refreshes.
-fn apply_sort(app: &mut App, sort_by: SortBy) -> anyhow::Result<()> {
-    if app.files.is_empty() {
-        return Ok(());
-    }
-
-    // Save sort preference to app state
-    app.sort_by = sort_by.clone();
-
-    // Get current directory path from first file in list
-    let cur_path = get_curr_path(app.files[0].clone());
-
-    // Get sorted file list using app's persisted sort state
-    let file_path_list = get_file_path_data(cur_path, app.show_hidden_files, app.sort_by.clone(), &app.sort_type)?;
-
-    // Update app state
-    app.files = file_path_list.clone();
-    app.read_only_files = file_path_list;
-    app.update_file_references();
-    app.input_mode = InputMode::Normal;
-
-    Ok(())
 }
 
 fn handle_file_selection(
@@ -1503,9 +1487,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
         // Handle input with timeout for dynamic progress updates
         let timeout = std::time::Duration::from_millis(100); // 100ms timeout
-        if let Ok(available) = event::poll(timeout) {
+        if let Ok(available) = crossterm_event::poll(timeout) {
             if available {
-                if let Event::Key(key) = event::read()? {
+                if let Event::Key(key) = crossterm_event::read()? {
                     match app.input_mode {
                         InputMode::Normal => match key.code {
                             KeyCode::Char('i') => {
@@ -1523,17 +1507,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 } else {
                                     let list_len = app.get_list_length();
 
-                                    if list_len > 0 {
-                                        let i = match state.selected() {
-                                            Some(i) => {
-                                                if i >= list_len - 1 {
-                                                    0
-                                                } else {
-                                                    i + 1
-                                                }
-                                            }
-                                            None => 0,
-                                        };
+                                    if let Some(i) = next_index_wrapping(state.selected(), list_len)
+                                    {
                                         state.select(Some(i));
                                         app.curr_index = Some(i);
 
@@ -1551,17 +1526,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 } else {
                                     let list_len = app.get_list_length();
 
-                                    if list_len > 0 {
-                                        let i = match state.selected() {
-                                            Some(i) => {
-                                                if i == 0 {
-                                                    list_len - 1
-                                                } else {
-                                                    i - 1
-                                                }
-                                            }
-                                            None => 0,
-                                        };
+                                    if let Some(i) =
+                                        previous_index_wrapping(state.selected(), list_len)
+                                    {
                                         state.select(Some(i));
                                         app.curr_index = Some(i);
 
@@ -1576,8 +1543,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 // In DualPane mode with right pane active, navigate right pane to parent
                                 if app.view_mode.is_dual_pane() && app.is_right_pane_active() {
                                     let current_dir = app.right_pane.current_directory.clone();
-                                    if let Some(parent) =
-                                        std::path::Path::new(&current_dir).parent()
+                                    if let Some(parent) = parent_directory(Path::new(&current_dir))
                                     {
                                         if let Some(parent_str) = parent.to_str() {
                                             app.right_pane.navigate_to_directory(parent_str);
@@ -1585,37 +1551,43 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     }
                                 } else if app.files.len() > 0 {
                                     let selected = &app.files[state.selected().unwrap()];
-                                    let mut split_path = selected.split("/").collect::<Vec<&str>>();
+                                    let selected_path = Path::new(selected);
 
                                     // TODO: refactor this to be more idiomatic
-                                    if split_path.len() > 4 {
-                                        split_path.pop();
-                                        split_path.pop();
+                                    if selected_path.components().count() > 4 {
+                                        let new_path = parent_directory(selected_path)
+                                            .and_then(|path| parent_directory(&path))
+                                            .map(|path| path.to_string_lossy().to_string());
 
-                                        let new_path = split_path.join("/");
-                                        let files_strings = get_inner_files_info(
-                                            new_path.clone(),
-                                            app.show_hidden_files,
-                                            app.sort_by.clone(),
-                                            &app.sort_type,
-                                        )
-                                        .unwrap();
+                                        if let Some(new_path) = new_path {
+                                            let files_strings = get_inner_files_info(
+                                                new_path.clone(),
+                                                app.show_hidden_files,
+                                                app.sort_by.clone(),
+                                                &app.sort_type,
+                                            )
+                                            .unwrap();
 
-                                        if let Some(f_s) = files_strings {
-                                            app.read_only_files = f_s.clone();
-                                            app.files = f_s;
-                                            app.update_file_references();
-                                            state.select(Some(0));
+                                            if let Some(f_s) = files_strings {
+                                                app.read_only_files = f_s.clone();
+                                                app.files = f_s;
+                                                app.update_file_references();
+                                                state.select(Some(0));
 
-                                            // Start watching the new directory
-                                            if let Err(e) = app.start_watching_directory(&new_path)
-                                            {
-                                                debug!(
+                                                // Start watching the new directory
+                                                if let Err(e) =
+                                                    app.start_watching_directory(&new_path)
+                                                {
+                                                    debug!(
                                                     "Failed to start watching directory '{}': {}",
                                                     new_path, e
                                                 );
-                                            } else {
-                                                debug!("Started watching directory: {}", new_path);
+                                                } else {
+                                                    debug!(
+                                                        "Started watching directory: {}",
+                                                        new_path
+                                                    );
+                                                }
                                             }
                                         }
                                     }
@@ -1902,14 +1874,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 let selected_index = state.selected();
                                 if let Some(index) = selected_index {
                                     let selected = &app.files[index];
-                                    let mut split_path = selected.split("/").collect::<Vec<&str>>();
-                                    let placeholder_name = split_path.pop().unwrap();
-                                    let new_path = split_path.join("/");
-                                    let placeholder_name_copy = placeholder_name;
-                                    app.current_path_to_edit = new_path;
-                                    app.current_name_to_edit = placeholder_name_copy.to_string();
-                                    app.create_edit_file_name = placeholder_name.to_string();
-                                    app.char_index = placeholder_name.len();
+                                    let selected_path = Path::new(selected);
+                                    if let Some((parent, placeholder_name)) =
+                                        rename_target(selected_path)
+                                    {
+                                        app.current_path_to_edit =
+                                            parent.to_string_lossy().to_string();
+                                        app.current_name_to_edit = placeholder_name.clone();
+                                        app.create_edit_file_name = placeholder_name.clone();
+                                        app.char_index = placeholder_name.len();
+                                    }
                                 }
                                 app.input_mode = InputMode::WatchRename;
                             }
@@ -1920,9 +1894,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 if let Some(indx) = selected_index {
                                     let selected = &app.files[indx];
 
-                                    let mut split_path = selected.split("/").collect::<Vec<&str>>();
-                                    split_path.pop();
-                                    let new_path = split_path.join("/");
+                                    let new_path = containing_directory(Path::new(selected))
+                                        .to_string_lossy()
+                                        .to_string();
                                     match get_inner_files_info(
                                         new_path,
                                         is_hidden,
@@ -1950,12 +1924,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         let src_path = Path::new(selected_path);
 
                                         // Get current directory (parent of selected item)
-                                        let current_dir = if src_path.is_file() {
-                                            src_path.parent().unwrap_or(Path::new("."))
-                                        } else {
-                                            // For directories, get the parent directory
-                                            src_path.parent().unwrap_or(Path::new("."))
-                                        };
+                                        let current_dir = containing_directory_or_current(src_path);
 
                                         // Generate copy name
                                         let new_path_with_new_name = generate_copy_file_dir_name(
@@ -2127,9 +2096,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     let new_path = if Path::new(selected).is_dir() {
                                         selected.clone()
                                     } else {
-                                        let mut split_path = selected.split("/").collect::<Vec<&str>>();
-                                        split_path.pop();
-                                        split_path.join("/")
+                                        create_target_directory(Path::new(selected))
+                                            .to_string_lossy()
+                                            .to_string()
                                     };
                                     match create_item_based_on_type(
                                         new_path.clone(),
@@ -2162,27 +2131,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             _ => {}
                         },
 
-                        InputMode::Editing if key.kind == KeyEventKind::Press => match key.code {
-                            KeyCode::Enter => app.submit_message(),
-                            KeyCode::Char(to_insert) => {
-                                app.enter_char(to_insert, store.clone());
-                            }
-                            KeyCode::Backspace => {
-                                app.delete_char(store.clone());
-                            }
-                            KeyCode::Left => {
-                                app.move_cursor_left();
-                            }
-
-                            KeyCode::Right => {
-                                app.move_cursor_right();
-                            }
-                            KeyCode::Esc => {
-                                app.input_mode = InputMode::Normal;
-                            }
-
-                            _ => {}
-                        },
+                        InputMode::Editing if key.kind == KeyEventKind::Press => {
+                            handle_search_key(&mut app, key.code, &store);
+                        }
                         InputMode::WatchDelete => match key.code {
                             KeyCode::Char('q') => {
                                 app.render_popup = false;
@@ -2200,9 +2151,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 if let Some(selected_indx) = selected_index {
                                     let selected = &app.files[selected_indx];
                                     // Get parent directory for refresh
-                                    let mut split_path = selected.split("/").collect::<Vec<&str>>();
-                                    split_path.pop();
-                                    let current_dir = split_path.join("/");
+                                    let current_dir = containing_directory(Path::new(selected))
+                                        .to_string_lossy()
+                                        .to_string();
 
                                     let path = Path::new(selected);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ use crate::{
     render::{
         create_cache_loading_screen, create_create_input_popup, create_delete_confirmation_popup,
         create_keybindings_popup, create_rename_input_popup, create_sort_options_popup,
-        draw_input_popup, draw_popup, split_popup_area_vertical,
+        draw_input_popup, draw_popup, input_popup_cursor_position, split_popup_area_vertical,
     },
     status_bar::StatusBar,
     theme::OneDarkTheme,
@@ -948,19 +948,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             match app.input_mode {
                 InputMode::Normal => {}
                 InputMode::WatchDelete => {}
-                InputMode::WatchCreate => {}
+                InputMode::WatchCreate => {
+                    let area = draw_input_popup(f.size());
+                    let (x, y) = input_popup_cursor_position(area, app.char_index);
+                    f.set_cursor(x, y);
+                }
                 InputMode::WatchRename => {
-                    // Place cursor inside the rename popup input, aligned to app.char_index
-                    let area = draw_popup(f.size(), 40, 7);
-                    let popup_chunks = Layout::default()
-                        .direction(Direction::Horizontal)
-                        .margin(1)
-                        .constraints([Constraint::Percentage(100)])
-                        .split(area);
-                    f.set_cursor(
-                        popup_chunks[0].x + app.char_index as u16 + 1,
-                        popup_chunks[0].y + 1,
-                    );
+                    let area = draw_input_popup(f.size());
+                    let (x, y) = input_popup_cursor_position(area, app.char_index);
+                    f.set_cursor(x, y);
                 }
                 InputMode::WatchSort => {}
                 InputMode::Editing => f.set_cursor(

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ use crate::{
     event::{
         file_actions::{
             containing_directory, containing_directory_or_current, create_target_directory,
-            rename_target,
+            refresh_file_list, rename_target,
         },
         navigation::{next_index_wrapping, parent_directory, previous_index_wrapping},
         search::handle_search_key,
@@ -71,8 +71,8 @@ use crate::{
     },
     render::{
         create_cache_loading_screen, create_create_input_popup, create_delete_confirmation_popup,
-        create_keybindings_popup, create_rename_input_popup, create_sort_options_popup, draw_popup,
-        split_popup_area, split_popup_area_vertical,
+        create_keybindings_popup, create_rename_input_popup, create_sort_options_popup,
+        draw_input_popup, draw_popup, split_popup_area_vertical,
     },
     status_bar::StatusBar,
     theme::OneDarkTheme,
@@ -1174,8 +1174,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
 
             // Popup areas using render module helpers
-            let popup_area = draw_popup(f.size(), 40, 7);
-            let popup_chunks = split_popup_area(popup_area);
+            let input_popup_area = draw_input_popup(f.size());
             let sort_option_area = draw_popup(f.size(), 90, 20);
             let sort_options_chunks = split_popup_area_vertical(sort_option_area);
             let keybinding_area = draw_popup(f.size(), 55, 75);
@@ -1188,12 +1187,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         app.is_create_edit_error,
                         &app.error_message,
                     );
-                    f.render_widget(Clear, popup_chunks[0]);
-                    f.render_widget(create_input_block, popup_chunks[0]);
+                    f.render_widget(Clear, input_popup_area);
+                    f.render_widget(create_input_block, input_popup_area);
                 }
                 InputMode::WatchRename => {
                     let rename_input_block = create_rename_input_popup(&app.create_edit_file_name);
-                    f.render_widget(rename_input_block, popup_chunks[0]);
+                    f.render_widget(Clear, input_popup_area);
+                    f.render_widget(rename_input_block, input_popup_area);
                 }
                 InputMode::WatchSort => {
                     let sort_popup = create_sort_options_popup(&app.sort_by, &app.sort_type);
@@ -2108,15 +2108,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                             app.input_mode = InputMode::Normal;
 
                                             app.reset_create_edit_values();
-                                            let file_path_list = get_file_path_data(
-                                                new_path,
-                                                app.show_hidden_files,
-                                                app.sort_by.clone(),
-                                                &app.sort_type,
-                                            )?;
-                                            app.files = file_path_list.clone();
-                                            app.read_only_files = file_path_list.clone();
-                                            app.update_file_references();
+                                            refresh_file_list(&mut app, Path::new(&new_path))?;
                                             status_bar.invalidate_cache();
                                             // Reset selection to first item to avoid index out of bounds
                                             state.select(Some(0));

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -7,7 +7,7 @@ pub mod size_bar;
 // Re-export items used by main.rs
 pub use popups::{
     create_create_input_popup, create_delete_confirmation_popup, create_keybindings_popup,
-    create_rename_input_popup, create_sort_options_popup, draw_popup, split_popup_area,
+    create_rename_input_popup, create_sort_options_popup, draw_input_popup, draw_popup,
     split_popup_area_vertical,
 };
 pub use preview::create_cache_loading_screen;

--- a/src/render/mod.rs
+++ b/src/render/mod.rs
@@ -8,7 +8,7 @@ pub mod size_bar;
 pub use popups::{
     create_create_input_popup, create_delete_confirmation_popup, create_keybindings_popup,
     create_rename_input_popup, create_sort_options_popup, draw_input_popup, draw_popup,
-    split_popup_area_vertical,
+    input_popup_cursor_position, split_popup_area_vertical,
 };
 pub use preview::create_cache_loading_screen;
 pub use size_bar::{create_size_text, get_file_size};

--- a/src/render/popups.rs
+++ b/src/render/popups.rs
@@ -32,6 +32,41 @@ pub fn draw_popup(rect: Rect, percent_x: u16, percent_y: u16) -> Rect {
     .split(popup_layout[1])[1]
 }
 
+/// Calculate a centered input popup area with a minimum size.
+pub fn draw_input_popup(rect: Rect) -> Rect {
+    draw_popup_with_min_size(rect, 40, 20, 30, 5)
+}
+
+fn draw_popup_with_min_size(
+    rect: Rect,
+    percent_x: u16,
+    percent_y: u16,
+    min_width: u16,
+    min_height: u16,
+) -> Rect {
+    let width = rect
+        .width
+        .saturating_mul(percent_x)
+        .checked_div(100)
+        .unwrap_or(0)
+        .max(min_width)
+        .min(rect.width);
+    let height = rect
+        .height
+        .saturating_mul(percent_y)
+        .checked_div(100)
+        .unwrap_or(0)
+        .max(min_height)
+        .min(rect.height);
+
+    Rect {
+        x: rect.x + rect.width.saturating_sub(width) / 2,
+        y: rect.y + rect.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
 /// Generate the sort indicator display string showing field and direction.
 pub fn generate_sort_indicator(sort_by: &SortBy, sort_type: &SortType) -> String {
     let field = match sort_by {
@@ -203,16 +238,6 @@ pub fn create_keybindings_popup<'a>() -> Paragraph<'a> {
         .style(OneDarkTheme::normal())
 }
 
-/// Split an area for popup content with margins.
-pub fn split_popup_area(area: Rect) -> Vec<Rect> {
-    Layout::default()
-        .direction(Direction::Horizontal)
-        .margin(1)
-        .constraints([Constraint::Percentage(100)])
-        .split(area)
-        .to_vec()
-}
-
 /// Split an area for vertical popup content with margins.
 pub fn split_popup_area_vertical(area: Rect) -> Vec<Rect> {
     Layout::default()
@@ -237,6 +262,14 @@ mod tests {
         assert!(popup.y > 0);
         assert!(popup.width < outer.width);
         assert!(popup.height < outer.height);
+    }
+
+    #[test]
+    fn test_draw_input_popup_has_enough_height_for_bordered_input() {
+        let outer = Rect::new(0, 0, 160, 24);
+        let popup = draw_input_popup(outer);
+
+        assert!(popup.height >= 5);
     }
 
     #[test]

--- a/src/render/popups.rs
+++ b/src/render/popups.rs
@@ -34,16 +34,10 @@ pub fn draw_popup(rect: Rect, percent_x: u16, percent_y: u16) -> Rect {
 
 /// Calculate a centered input popup area with a minimum size.
 pub fn draw_input_popup(rect: Rect) -> Rect {
-    draw_popup_with_min_size(rect, 40, 20, 30, 5)
+    draw_fixed_height_popup(rect, 40, 30, 3)
 }
 
-fn draw_popup_with_min_size(
-    rect: Rect,
-    percent_x: u16,
-    percent_y: u16,
-    min_width: u16,
-    min_height: u16,
-) -> Rect {
+fn draw_fixed_height_popup(rect: Rect, percent_x: u16, min_width: u16, height: u16) -> Rect {
     let width = rect
         .width
         .saturating_mul(percent_x)
@@ -51,13 +45,7 @@ fn draw_popup_with_min_size(
         .unwrap_or(0)
         .max(min_width)
         .min(rect.width);
-    let height = rect
-        .height
-        .saturating_mul(percent_y)
-        .checked_div(100)
-        .unwrap_or(0)
-        .max(min_height)
-        .min(rect.height);
+    let height = height.min(rect.height);
 
     Rect {
         x: rect.x + rect.width.saturating_sub(width) / 2,
@@ -65,6 +53,14 @@ fn draw_popup_with_min_size(
         width,
         height,
     }
+}
+
+/// Calculate the terminal cursor position for a one-line bordered input popup.
+pub fn input_popup_cursor_position(area: Rect, char_index: usize) -> (u16, u16) {
+    let inner_width = area.width.saturating_sub(2);
+    let cursor_offset = (char_index as u16).min(inner_width.saturating_sub(1));
+
+    (area.x + 1 + cursor_offset, area.y + 1)
 }
 
 /// Generate the sort indicator display string showing field and direction.
@@ -265,11 +261,18 @@ mod tests {
     }
 
     #[test]
-    fn test_draw_input_popup_has_enough_height_for_bordered_input() {
+    fn test_draw_input_popup_is_compact_bordered_input() {
         let outer = Rect::new(0, 0, 160, 24);
         let popup = draw_input_popup(outer);
 
-        assert!(popup.height >= 5);
+        assert_eq!(popup.height, 3);
+    }
+
+    #[test]
+    fn test_input_popup_cursor_position_uses_inner_input_row() {
+        let popup = Rect::new(20, 10, 40, 3);
+
+        assert_eq!(input_popup_cursor_position(popup, 9), (30, 11));
     }
 
     #[test]

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -5,7 +5,10 @@ use std::time::Duration;
 
 use log::{debug, error};
 use notify::PollWatcher;
-use notify::{Config, Event, EventKind, RecursiveMode, Result as NotifyResult, Watcher};
+use notify::{
+    Config, Error as NotifyError, ErrorKind as NotifyErrorKind, Event, EventKind, RecursiveMode,
+    Result as NotifyResult, Watcher,
+};
 
 type WatcherBackend = PollWatcher;
 
@@ -141,10 +144,13 @@ impl FileSystemWatcher {
                     }
                 }
                 Ok(Err(e)) => {
-                    error!("File watcher error: {}", e);
-                    if let Err(send_err) =
-                        event_sender.send(WatcherEvent::WatcherError(e.to_string()))
-                    {
+                    let watcher_event = Self::event_from_watcher_error(&e, &watched_path)
+                        .unwrap_or_else(|| {
+                            error!("File watcher error: {}", e);
+                            WatcherEvent::WatcherError(e.to_string())
+                        });
+
+                    if let Err(send_err) = event_sender.send(watcher_event) {
                         error!("Failed to send watcher error: {}", send_err);
                         break;
                     }
@@ -194,6 +200,33 @@ impl FileSystemWatcher {
             }
         }
         false
+    }
+
+    fn event_from_watcher_error(error: &NotifyError, watched_path: &Path) -> Option<WatcherEvent> {
+        if !Self::is_not_found_error(&error.kind) {
+            return None;
+        }
+
+        let deleted_paths: Vec<PathBuf> = error
+            .paths
+            .iter()
+            .filter(|path| path.parent() == Some(watched_path) && !path.exists())
+            .cloned()
+            .collect();
+
+        if deleted_paths.is_empty() {
+            None
+        } else {
+            Some(WatcherEvent::FilesDeleted(deleted_paths))
+        }
+    }
+
+    fn is_not_found_error(error_kind: &NotifyErrorKind) -> bool {
+        matches!(error_kind, NotifyErrorKind::PathNotFound)
+            || matches!(
+                error_kind,
+                NotifyErrorKind::Io(error) if error.kind() == std::io::ErrorKind::NotFound
+            )
     }
 
     /// Process a batch of events and return a single application event
@@ -346,6 +379,21 @@ mod tests {
                 || events
                     .iter()
                     .any(|event| { matches!(event, WatcherEvent::DirectoryChanged) })
+        );
+    }
+
+    #[test]
+    fn not_found_error_for_direct_child_becomes_deleted_event() {
+        let dir = tempdir().unwrap();
+        let deleted_file = dir.path().join("deleted.txt");
+        let error = notify::Error::io(std::io::Error::from(std::io::ErrorKind::NotFound))
+            .set_paths(vec![deleted_file.clone()]);
+
+        let event = FileSystemWatcher::event_from_watcher_error(&error, dir.path());
+
+        assert!(
+            matches!(&event, Some(WatcherEvent::FilesDeleted(paths)) if paths == &vec![deleted_file]),
+            "expected missing direct child error to be treated as delete event, got {event:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Extract keyboard navigation, search, sort, and file-action helpers into the new event module.
- Preserve current hidden-file and sort settings when refreshing after create operations.
- Use compact fixed-height create/rename input popups with shared cursor positioning.

## Test Plan
- [x] git diff --check main...HEAD
- [x] cargo check --all-targets --quiet
- [x] cargo test --quiet
- [x] Manual testing: create/delete refresh, create popup sizing, rename cursor placement