### PR TITLE
update: normalize current directory path handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Instant;
 
@@ -932,16 +932,24 @@ impl App {
         }
     }
 
-    /// Get the current directory path from the first file in the list.
-    /// Returns the parent directory of the first file, or an empty string if no files.
+    /// Get the active current directory as a string.
     pub fn get_current_dir(&self) -> String {
-        if let Some(first_file) = self.files.first() {
-            let path = Path::new(first_file);
-            path.parent()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_default()
+        self.current_directory_path().to_string_lossy().to_string()
+    }
+
+    /// Get the active current directory as a path.
+    pub fn current_directory_path(&self) -> PathBuf {
+        if self.view_mode.is_dual_pane() && self.is_right_pane_active() {
+            PathBuf::from(&self.right_pane.current_directory)
+        } else if !self.current_directory.is_empty() {
+            PathBuf::from(&self.current_directory)
+        } else if let Some(first_file) = self.files.first() {
+            Path::new(first_file)
+                .parent()
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| PathBuf::from("."))
         } else {
-            String::new()
+            PathBuf::from(".")
         }
     }
 
@@ -1029,3 +1037,37 @@ impl App {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn current_directory_path_falls_back_to_dot_without_state() {
+        let app = App::new(Vec::new());
+
+        assert_eq!(app.current_directory_path(), PathBuf::from("."));
+    }
+
+    #[test]
+    fn current_directory_path_uses_watched_directory_when_files_empty() {
+        let mut app = App::new(Vec::new());
+        app.current_directory = "/tmp/ff-empty-current".to_string();
+
+        assert_eq!(
+            app.current_directory_path(),
+            PathBuf::from("/tmp/ff-empty-current")
+        );
+    }
+
+    #[test]
+    fn current_directory_path_uses_active_right_pane_directory() {
+        let mut app = App::new(vec!["/tmp/ff-left/file.txt".to_string()]);
+        app.current_directory = "/tmp/ff-left".to_string();
+        app.view_mode = ViewMode::DualPane;
+        app.active_pane = PanePosition::Right;
+        app.right_pane = crate::pane::Pane::new("/tmp/ff-right".to_string(), Vec::new());
+
+        assert_eq!(app.current_directory_path(), PathBuf::from("/tmp/ff-right"));
+    }
+}

--- a/src/event/file_actions.rs
+++ b/src/event/file_actions.rs
@@ -68,8 +68,11 @@ mod tests {
     }
 
     #[test]
-    fn containing_directory_or_current_falls_back_to_current_directory() {
-        assert_eq!(containing_directory_or_current(Path::new("/")), PathBuf::from("."));
+    fn containing_directory_or_current_preserves_root_directory() {
+        assert_eq!(
+            containing_directory_or_current(Path::new("/")),
+            PathBuf::from("/")
+        );
     }
 
     #[test]

--- a/src/event/navigation.rs
+++ b/src/event/navigation.rs
@@ -1,7 +1,9 @@
 use std::path::{Path, PathBuf};
 
 pub fn parent_directory(path: &Path) -> Option<PathBuf> {
-    path.parent().map(Path::to_path_buf)
+    path.parent()
+        .map(Path::to_path_buf)
+        .or_else(|| path.has_root().then(|| PathBuf::from("/")))
 }
 
 pub fn next_index(current: Option<usize>, len: usize) -> Option<usize> {
@@ -65,6 +67,11 @@ mod tests {
             parent_directory(Path::new("/tmp/example/file.txt")),
             Some(PathBuf::from("/tmp/example"))
         );
+    }
+
+    #[test]
+    fn parent_directory_of_root_stays_root() {
+        assert_eq!(parent_directory(Path::new("/")), Some(PathBuf::from("/")));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 // Standard library imports
 use std::{
     io::{self, Stdout},
-    path::Path,
+    path::{Path, PathBuf},
     process::Command,
     sync::mpsc,
 };
@@ -114,12 +114,12 @@ fn startup_paths(effective_config: &crate::cli::EffectiveConfig) -> StartupPaths
 }
 
 fn current_refresh_directory(app: &App, fallback_start_path: &str) -> String {
-    if !app.files.is_empty() {
-        get_curr_path(app.files[0].clone())
-    } else if !app.current_directory.is_empty() {
-        app.current_directory.clone()
-    } else {
+    let current_directory = app.current_directory_path();
+
+    if current_directory == PathBuf::from(".") {
         fallback_start_path.to_string()
+    } else {
+        current_directory.to_string_lossy().to_string()
     }
 }
 
@@ -493,6 +493,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         &SortType::ASC,
     )?;
     let mut app = App::new(file_strings.clone());
+    app.current_directory = startup_paths.file_list_path.clone();
 
     // Initialize config and theme after app creation
     if let Err(e) = app.initialize_config_and_theme() {
@@ -2289,13 +2290,13 @@ mod tests {
     }
 
     #[test]
-    fn refresh_directory_prefers_visible_file_list_when_available() {
+    fn refresh_directory_prefers_tracked_current_directory_when_available() {
         let mut app = App::new(vec!["/tmp/ff-visible/file.txt".to_string()]);
-        app.current_directory = "/tmp/ff-stale-current".to_string();
+        app.current_directory = "/tmp/ff-current".to_string();
 
         assert_eq!(
             current_refresh_directory(&app, "/tmp/ff-settings-start"),
-            "/tmp/ff-visible"
+            "/tmp/ff-current"
         );
     }
 }

--- a/src/utils/files.rs
+++ b/src/utils/files.rs
@@ -281,9 +281,10 @@ pub fn check_if_exists(new_path: String) -> bool {
 
 /// Get the parent directory path from a file path.
 pub fn get_curr_path(path: String) -> String {
-    let mut split_path = path.split('/').collect::<Vec<&str>>();
-    split_path.pop();
-    split_path.join("/")
+    Path::new(&path)
+        .parent()
+        .map(|parent| parent.to_string_lossy().to_string())
+        .unwrap_or_default()
 }
 
 /// Get directory statistics (file count and total size).
@@ -333,7 +334,7 @@ mod tests {
     fn test_get_curr_path() {
         assert_eq!(get_curr_path("/foo/bar/baz.txt".to_string()), "/foo/bar");
         assert_eq!(get_curr_path("/foo/bar".to_string()), "/foo");
-        assert_eq!(get_curr_path("/foo".to_string()), "");
+        assert_eq!(get_curr_path("/foo".to_string()), "/");
     }
 
     #[test]

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -146,7 +146,7 @@ mod path_handling_tests {
     fn test_get_curr_path_root() {
         let path = "/file.txt".to_string();
         let parent = get_curr_path(path);
-        assert_eq!(parent, "");
+        assert_eq!(parent, "/");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add a PathBuf-based current-directory accessor and use it for refresh decisions.
- Initialize app current directory from the effective start path so empty directories retain their watched path.
- Normalize parent-path handling for root paths and replace brittle slash splitting.

## Test Plan
- [x] cargo test --quiet
- [x] cargo check --all-targets --quiet
- [x] Manual smoke test against /tmp/ff-path-smoke for create/delete refresh and empty-directory behavior