### PR TITLE
docs: clarify config and theme ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,9 @@ use_nerd_fonts = "auto"    # Auto-detect (default)
 - **Cache**: `~/.config/ff/cache_directory.json`
 - **Themes**: `~/.config/ff/themes/`
 
+`ff` stores active TOML settings under `~/.config/ff/settings.toml`.
+Legacy JSON configuration is compatibility-only and should not be used for new settings.
+
 ### Precedence
 
 1. CLI arguments

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,3 +1,8 @@
+//! Active TOML-backed user settings for ff.
+//!
+//! New runtime configuration should be added here. `src/configuration.rs`
+//! is legacy JSON compatibility and should not receive new settings.
+
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
@@ -229,4 +234,3 @@ impl Settings {
         self.save()
     }
 }
-

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -1,3 +1,8 @@
+//! Active TOML-backed theme configuration for ff.
+//!
+//! Configured runtime colors are loaded here and converted into `ThemeColors`.
+//! Widget-local static style helpers live in `src/ui/theme.rs`.
+
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,3 +1,8 @@
+//! Legacy JSON configuration support.
+//!
+//! This module is kept for compatibility with older tests/config files.
+//! New settings belong in `src/config/settings.rs`.
+
 use std::{
     fs::{self, File},
     io::{BufReader, BufWriter},

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,3 +1,8 @@
+//! Legacy OneDark helpers.
+//!
+//! Runtime UI code should prefer `src/config/theme.rs` for configured colors
+//! and `src/ui/theme.rs` for widget-local styles.
+
 use ratatui::style::{Color, Modifier, Style};
 
 /// OneDark theme colors matching lazygit configuration

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,7 +1,7 @@
-//! One Dark Darker Theme
+//! Widget-local One Dark Darker theme helpers.
 //!
-//! Centralized theme colors based on navarasu/onedark.nvim "darker" style.
-//! All UI colors should reference this module for consistency.
+//! Centralized static styles based on navarasu/onedark.nvim "darker" style.
+//! Configurable runtime colors live in `src/config/theme.rs`.
 
 use ratatui::style::{Color, Modifier, Style};
 


### PR DESCRIPTION
## Summary
- Document active TOML settings and theme ownership.
- Mark legacy JSON config and legacy OneDark helpers as compatibility paths.
- Update README configuration notes for future settings work.

## Test Plan
- [x] cargo test --quiet
- [x] cargo check --all-targets --quiet
- [x] No manual test needed; docs/comments only