### PR TITLE
update: apply rustfmt baseline

### DIFF
--- a/examples/performance_test.rs
+++ b/examples/performance_test.rs
@@ -1,15 +1,15 @@
-use std::time::Instant;
 use file_finder::highlight::highlight_search_term;
 use file_finder::ui::theme::OneDarkTheme;
 use ratatui::{text::Line, widgets::ListItem};
+use std::time::Instant;
 
 fn main() {
     println!("🚀 Search Highlighting Performance Analysis");
     println!("==========================================");
-    
+
     // Generate realistic test data
-    let test_files: Vec<String> = (0..10000).map(|i| {
-        match i % 10 {
+    let test_files: Vec<String> = (0..10000)
+        .map(|i| match i % 10 {
             0 => format!("src/main_{}.rs", i),
             1 => format!("src/lib_{}.rs", i),
             2 => format!("src/utils_{}.rs", i),
@@ -20,11 +20,11 @@ fn main() {
             7 => format!("config/config_{}.toml", i),
             8 => format!("assets/asset_{}.png", i),
             _ => format!("other/file_{}.txt", i),
-        }
-    }).collect();
-    
+        })
+        .collect();
+
     println!("📊 Testing with {} files", test_files.len());
-    
+
     // Scenario 1: Baseline - Simple string operations (no highlighting)
     let start = Instant::now();
     let _simple: Vec<String> = test_files
@@ -32,20 +32,22 @@ fn main() {
         .map(|file| format!("📄 {}", file))
         .collect();
     let baseline_duration = start.elapsed();
-    
-    // Scenario 2: With highlighting 
+
+    // Scenario 2: With highlighting
     let start = Instant::now();
     let _highlighted: Vec<Line> = test_files
         .iter()
-        .map(|file| highlight_search_term(
-            file,
-            "src",
-            OneDarkTheme::normal(),
-            OneDarkTheme::search_highlight()
-        ))
+        .map(|file| {
+            highlight_search_term(
+                file,
+                "src",
+                OneDarkTheme::normal(),
+                OneDarkTheme::search_highlight(),
+            )
+        })
         .collect();
     let highlighting_duration = start.elapsed();
-    
+
     // Scenario 3: Full UI construction (realistic scenario)
     let start = Instant::now();
     let _ui_items: Vec<ListItem> = test_files
@@ -55,55 +57,76 @@ fn main() {
                 file,
                 "src",
                 OneDarkTheme::normal(),
-                OneDarkTheme::search_highlight()
+                OneDarkTheme::search_highlight(),
             );
-            
-            let mut spans = vec![
-                ratatui::text::Span::styled("📄 ", OneDarkTheme::normal())
-            ];
+
+            let mut spans = vec![ratatui::text::Span::styled("📄 ", OneDarkTheme::normal())];
             spans.extend(highlighted_line.spans);
-            
+
             ListItem::from(Line::from(spans))
         })
         .collect();
     let full_ui_duration = start.elapsed();
-    
+
     // Calculate metrics
-    let overhead_micros = highlighting_duration.as_micros() as f64 - baseline_duration.as_micros() as f64;
+    let overhead_micros =
+        highlighting_duration.as_micros() as f64 - baseline_duration.as_micros() as f64;
     let overhead_percentage = (overhead_micros / baseline_duration.as_micros() as f64) * 100.0;
     let per_file_cost = overhead_micros / test_files.len() as f64;
-    
+
     println!("\n📈 Performance Results:");
     println!("  Baseline (no highlighting):      {:?}", baseline_duration);
-    println!("  With highlighting:               {:?}", highlighting_duration);
+    println!(
+        "  With highlighting:               {:?}",
+        highlighting_duration
+    );
     println!("  Full UI construction:            {:?}", full_ui_duration);
-    
+
     println!("\n💡 Performance Analysis:");
-    println!("  Highlighting overhead:           {:.2}μs ({:.1}%)", overhead_micros, overhead_percentage);
+    println!(
+        "  Highlighting overhead:           {:.2}μs ({:.1}%)",
+        overhead_micros, overhead_percentage
+    );
     println!("  Per-file highlighting cost:      {:.3}μs", per_file_cost);
-    println!("  Files per millisecond:           {:.0}", 1000.0 / per_file_cost);
-    
+    println!(
+        "  Files per millisecond:           {:.0}",
+        1000.0 / per_file_cost
+    );
+
     // Real-world scenarios
     println!("\n🌍 Real-world Impact:");
-    
+
     // Typical search scenario (50 visible files)
     let visible_files: Vec<String> = test_files.iter().take(50).cloned().collect();
-    
+
     let start = Instant::now();
-    for _ in 0..1000 { // Simulate 1000 UI renders
+    for _ in 0..1000 {
+        // Simulate 1000 UI renders
         let _: Vec<Line> = visible_files
             .iter()
-            .map(|file| highlight_search_term(file, "src", OneDarkTheme::normal(), OneDarkTheme::search_highlight()))
+            .map(|file| {
+                highlight_search_term(
+                    file,
+                    "src",
+                    OneDarkTheme::normal(),
+                    OneDarkTheme::search_highlight(),
+                )
+            })
             .collect();
     }
     let realistic_duration = start.elapsed();
-    
+
     println!("  1000 renders of 50 files:       {:?}", realistic_duration);
-    println!("  Per-render cost:                 {:?}", realistic_duration / 1000);
+    println!(
+        "  Per-render cost:                 {:?}",
+        realistic_duration / 1000
+    );
     println!("  60 FPS frame budget:             16.67ms");
-    println!("  Highlighting uses:               {:.4}% of frame budget", 
-        (realistic_duration.as_micros() as f64 / 1000.0) / 16670.0 * 100.0);
-    
+    println!(
+        "  Highlighting uses:               {:.4}% of frame budget",
+        (realistic_duration.as_micros() as f64 / 1000.0) / 16670.0 * 100.0
+    );
+
     // Different search term lengths
     println!("\n📏 Search Term Length Impact:");
     let search_terms = vec!["a", "rs", "src", "main", "config", "component"];
@@ -111,22 +134,30 @@ fn main() {
         let start = Instant::now();
         let _: Vec<Line> = visible_files
             .iter()
-            .map(|file| highlight_search_term(file, term, OneDarkTheme::normal(), OneDarkTheme::search_highlight()))
+            .map(|file| {
+                highlight_search_term(
+                    file,
+                    term,
+                    OneDarkTheme::normal(),
+                    OneDarkTheme::search_highlight(),
+                )
+            })
             .collect();
         let duration = start.elapsed();
-        
-        println!("  '{}' ({} chars):  {:?} ({:.3}μs/file)", 
-            term, 
-            term.len(), 
+
+        println!(
+            "  '{}' ({} chars):  {:?} ({:.3}μs/file)",
+            term,
+            term.len(),
             duration,
             duration.as_micros() as f64 / visible_files.len() as f64
         );
     }
-    
+
     // Match frequency impact
     println!("\n🎯 Match Frequency Impact:");
     test_match_frequency();
-    
+
     println!("\n✅ Conclusion:");
     if per_file_cost < 1.0 {
         println!("  🟢 Excellent: < 1μs per file");
@@ -135,50 +166,72 @@ fn main() {
     } else {
         println!("  🔴 Consider optimization: > 5μs per file");
     }
-    
+
     println!("  📝 The highlighting feature adds minimal overhead");
     println!("     and significantly improves user experience!");
 }
 
 fn test_match_frequency() {
     // High match frequency (80% of files contain "src")
-    let high_match_files: Vec<String> = (0..1000).map(|i| {
-        if i % 5 != 0 {
-            format!("src/file_{}.rs", i)
-        } else {
-            format!("other/file_{}.txt", i)
-        }
-    }).collect();
-    
+    let high_match_files: Vec<String> = (0..1000)
+        .map(|i| {
+            if i % 5 != 0 {
+                format!("src/file_{}.rs", i)
+            } else {
+                format!("other/file_{}.txt", i)
+            }
+        })
+        .collect();
+
     // Low match frequency (10% of files contain "rare")
-    let low_match_files: Vec<String> = (0..1000).map(|i| {
-        if i % 10 == 0 {
-            format!("rare_file_{}.rs", i)
-        } else {
-            format!("common_file_{}.txt", i)
-        }
-    }).collect();
-    
+    let low_match_files: Vec<String> = (0..1000)
+        .map(|i| {
+            if i % 10 == 0 {
+                format!("rare_file_{}.rs", i)
+            } else {
+                format!("common_file_{}.txt", i)
+            }
+        })
+        .collect();
+
     // Test high match frequency
     let start = Instant::now();
     let _: Vec<Line> = high_match_files
         .iter()
-        .map(|file| highlight_search_term(file, "src", OneDarkTheme::normal(), OneDarkTheme::search_highlight()))
+        .map(|file| {
+            highlight_search_term(
+                file,
+                "src",
+                OneDarkTheme::normal(),
+                OneDarkTheme::search_highlight(),
+            )
+        })
         .collect();
     let high_freq_duration = start.elapsed();
-    
-    // Test low match frequency  
+
+    // Test low match frequency
     let start = Instant::now();
     let _: Vec<Line> = low_match_files
         .iter()
-        .map(|file| highlight_search_term(file, "rare", OneDarkTheme::normal(), OneDarkTheme::search_highlight()))
+        .map(|file| {
+            highlight_search_term(
+                file,
+                "rare",
+                OneDarkTheme::normal(),
+                OneDarkTheme::search_highlight(),
+            )
+        })
         .collect();
     let low_freq_duration = start.elapsed();
-    
-    println!("  High frequency (80% matches): {:?} ({:.3}μs/file)", 
-        high_freq_duration, 
-        high_freq_duration.as_micros() as f64 / 1000.0);
-    println!("  Low frequency (10% matches):  {:?} ({:.3}μs/file)", 
-        low_freq_duration, 
-        low_freq_duration.as_micros() as f64 / 1000.0);
+
+    println!(
+        "  High frequency (80% matches): {:?} ({:.3}μs/file)",
+        high_freq_duration,
+        high_freq_duration.as_micros() as f64 / 1000.0
+    );
+    println!(
+        "  Low frequency (10% matches):  {:?} ({:.3}μs/file)",
+        low_freq_duration,
+        low_freq_duration.as_micros() as f64 / 1000.0
+    );
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -28,15 +28,9 @@ pub enum PreviewMessage {
         highlighted_content: Option<String>,
     },
     /// Directory contents loaded
-    DirectoryListing {
-        path: String,
-        entries: Vec<String>,
-    },
+    DirectoryListing { path: String, entries: Vec<String> },
     /// Preview loading failed
-    Error {
-        path: String,
-        message: String,
-    },
+    Error { path: String, message: String },
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -127,7 +121,6 @@ pub struct SearchResult {
     pub original_index: usize,
 }
 
-
 #[derive(Debug)]
 pub struct App {
     pub input: String,
@@ -178,7 +171,6 @@ pub struct App {
     pub copy_progress_message: String,
     pub copy_files_processed: usize,
     pub copy_total_files: usize,
-
 
     // File system watcher for real-time updates
     pub file_watcher: Option<FileSystemWatcher>,
@@ -297,7 +289,6 @@ impl App {
             copy_progress_message: String::new(),
             copy_files_processed: 0,
             copy_total_files: 0,
-
 
             // Initialize file watcher
             file_watcher: None,
@@ -650,9 +641,7 @@ impl App {
         if !self.input.is_empty() && self.input_mode != InputMode::Editing {
             self.input.clear();
         }
-
     }
-
 
     /// Start watching a directory for file system changes
     pub fn start_watching_directory<P: AsRef<Path>>(
@@ -989,10 +978,8 @@ impl App {
     /// Called when entering dual-pane mode
     pub fn init_right_pane(&mut self) {
         // Clone current directory and files to right pane
-        self.right_pane = crate::pane::Pane::new(
-            self.current_directory.clone(),
-            self.files.clone(),
-        );
+        self.right_pane =
+            crate::pane::Pane::new(self.current_directory.clone(), self.files.clone());
         self.right_pane.show_hidden_files = self.show_hidden_files;
     }
 
@@ -1019,7 +1006,8 @@ impl App {
     /// Check if a pending preview is ready to load (debounce period elapsed)
     /// Returns the path if ready, None otherwise
     pub fn take_ready_preview(&mut self, debounce_ms: u64) -> Option<String> {
-        if let (Some(path), Some(since)) = (&self.preview_pending_path, self.preview_pending_since) {
+        if let (Some(path), Some(since)) = (&self.preview_pending_path, self.preview_pending_since)
+        {
             if since.elapsed().as_millis() >= debounce_ms as u128 {
                 let path = path.clone();
                 self.preview_pending_path = None;

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -76,7 +76,6 @@ pub struct Settings {
     pub syntax_theme: String,
 
     // === UI Modernization Settings ===
-
     /// Layout style: "classic", "modern", or "miller"
     #[serde(default)]
     pub layout_style: LayoutStyle,

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -189,14 +189,14 @@ impl Default for UiTheme {
 impl Default for SyntaxTheme {
     fn default() -> Self {
         Self {
-            keyword: "#bf68d9".to_string(),   // purple
-            function: "#4fa6ed".to_string(),  // blue
-            r#type: "#e2b86b".to_string(),    // yellow
-            string: "#8ebd6b".to_string(),    // green
-            number: "#cc9057".to_string(),    // orange
-            comment: "#535965".to_string(),   // gray
-            operator: "#48b0bd".to_string(),  // cyan
-            variable: "#e55561".to_string(),  // red
+            keyword: "#bf68d9".to_string(),  // purple
+            function: "#4fa6ed".to_string(), // blue
+            r#type: "#e2b86b".to_string(),   // yellow
+            string: "#8ebd6b".to_string(),   // green
+            number: "#cc9057".to_string(),   // orange
+            comment: "#535965".to_string(),  // gray
+            operator: "#48b0bd".to_string(), // cyan
+            variable: "#e55561".to_string(), // red
         }
     }
 }
@@ -204,47 +204,47 @@ impl Default for SyntaxTheme {
 impl Default for IconTheme {
     fn default() -> Self {
         Self {
-            directory: "#4fa6ed".to_string(),   // blue
-            rust: "#dea584".to_string(),        // rust orange
-            javascript: "#e2b86b".to_string(),  // yellow
-            typescript: "#4fa6ed".to_string(),  // blue
-            python: "#4fa6ed".to_string(),      // blue
-            go: "#48b0bd".to_string(),          // cyan
-            java: "#cc9057".to_string(),        // orange
-            c: "#7a818e".to_string(),           // light_gray
-            cpp: "#bf68d9".to_string(),         // purple
-            ruby: "#e55561".to_string(),        // red
-            php: "#bf68d9".to_string(),         // purple
-            swift: "#cc9057".to_string(),       // orange
-            kotlin: "#bf68d9".to_string(),      // purple
-            lua: "#4fa6ed".to_string(),         // blue
-            shell: "#8ebd6b".to_string(),       // green
-            html: "#cc9057".to_string(),        // orange
-            css: "#bf68d9".to_string(),         // purple
-            vue: "#8ebd6b".to_string(),         // green
-            react: "#48b0bd".to_string(),       // cyan
-            svelte: "#cc9057".to_string(),      // orange
-            json: "#e2b86b".to_string(),        // yellow
-            yaml: "#e55561".to_string(),        // red
-            toml: "#cc9057".to_string(),        // orange
-            xml: "#4fa6ed".to_string(),         // blue
-            markdown: "#48b0bd".to_string(),    // cyan
-            config: "#7a818e".to_string(),      // light_gray
-            image: "#bf68d9".to_string(),       // purple
-            video: "#e55561".to_string(),       // red
-            audio: "#cc9057".to_string(),       // orange
-            pdf: "#e55561".to_string(),         // red
-            archive: "#e2b86b".to_string(),     // yellow
-            git: "#cc9057".to_string(),         // orange
-            key: "#e2b86b".to_string(),         // yellow
-            lock: "#e2b86b".to_string(),        // yellow
-            database: "#48b0bd".to_string(),    // cyan
-            docker: "#48b0bd".to_string(),      // cyan
-            license: "#e2b86b".to_string(),     // yellow
-            readme: "#e2b86b".to_string(),      // yellow
-            binary: "#7a818e".to_string(),      // light_gray
-            font: "#e55561".to_string(),        // red
-            default: "#a0a8b7".to_string(),     // fg
+            directory: "#4fa6ed".to_string(),  // blue
+            rust: "#dea584".to_string(),       // rust orange
+            javascript: "#e2b86b".to_string(), // yellow
+            typescript: "#4fa6ed".to_string(), // blue
+            python: "#4fa6ed".to_string(),     // blue
+            go: "#48b0bd".to_string(),         // cyan
+            java: "#cc9057".to_string(),       // orange
+            c: "#7a818e".to_string(),          // light_gray
+            cpp: "#bf68d9".to_string(),        // purple
+            ruby: "#e55561".to_string(),       // red
+            php: "#bf68d9".to_string(),        // purple
+            swift: "#cc9057".to_string(),      // orange
+            kotlin: "#bf68d9".to_string(),     // purple
+            lua: "#4fa6ed".to_string(),        // blue
+            shell: "#8ebd6b".to_string(),      // green
+            html: "#cc9057".to_string(),       // orange
+            css: "#bf68d9".to_string(),        // purple
+            vue: "#8ebd6b".to_string(),        // green
+            react: "#48b0bd".to_string(),      // cyan
+            svelte: "#cc9057".to_string(),     // orange
+            json: "#e2b86b".to_string(),       // yellow
+            yaml: "#e55561".to_string(),       // red
+            toml: "#cc9057".to_string(),       // orange
+            xml: "#4fa6ed".to_string(),        // blue
+            markdown: "#48b0bd".to_string(),   // cyan
+            config: "#7a818e".to_string(),     // light_gray
+            image: "#bf68d9".to_string(),      // purple
+            video: "#e55561".to_string(),      // red
+            audio: "#cc9057".to_string(),      // orange
+            pdf: "#e55561".to_string(),        // red
+            archive: "#e2b86b".to_string(),    // yellow
+            git: "#cc9057".to_string(),        // orange
+            key: "#e2b86b".to_string(),        // yellow
+            lock: "#e2b86b".to_string(),       // yellow
+            database: "#48b0bd".to_string(),   // cyan
+            docker: "#48b0bd".to_string(),     // cyan
+            license: "#e2b86b".to_string(),    // yellow
+            readme: "#e2b86b".to_string(),     // yellow
+            binary: "#7a818e".to_string(),     // light_gray
+            font: "#e55561".to_string(),       // red
+            default: "#a0a8b7".to_string(),    // fg
         }
     }
 }
@@ -252,19 +252,19 @@ impl Default for IconTheme {
 impl Default for MarkdownTheme {
     fn default() -> Self {
         Self {
-            header_1: "#e55561".to_string(),    // red
-            header_2: "#e2b86b".to_string(),    // yellow
-            header_3: "#8ebd6b".to_string(),    // green
-            header_4: "#4fa6ed".to_string(),    // blue
-            bold: "#cc9057".to_string(),        // orange
-            italic: "#bf68d9".to_string(),      // purple
-            code: "#8ebd6b".to_string(),        // green
-            code_bg: "#282c34".to_string(),     // bg_lighter
-            link: "#4fa6ed".to_string(),        // blue
-            link_url: "#535965".to_string(),    // gray
-            blockquote: "#7a818e".to_string(),  // light_gray
-            list_marker: "#bf68d9".to_string(), // purple
-            table_border: "#535965".to_string(),// gray
+            header_1: "#e55561".to_string(),        // red
+            header_2: "#e2b86b".to_string(),        // yellow
+            header_3: "#8ebd6b".to_string(),        // green
+            header_4: "#4fa6ed".to_string(),        // blue
+            bold: "#cc9057".to_string(),            // orange
+            italic: "#bf68d9".to_string(),          // purple
+            code: "#8ebd6b".to_string(),            // green
+            code_bg: "#282c34".to_string(),         // bg_lighter
+            link: "#4fa6ed".to_string(),            // blue
+            link_url: "#535965".to_string(),        // gray
+            blockquote: "#7a818e".to_string(),      // light_gray
+            list_marker: "#bf68d9".to_string(),     // purple
+            table_border: "#535965".to_string(),    // gray
             horizontal_rule: "#535965".to_string(), // gray
         }
     }
@@ -273,12 +273,12 @@ impl Default for MarkdownTheme {
 impl Default for StatusBarTheme {
     fn default() -> Self {
         Self {
-            background: "#181b20".to_string(),  // bg_dark
-            foreground: "#a0a8b7".to_string(),  // fg
-            mode_normal: "#4fa6ed".to_string(), // blue
-            mode_insert: "#8ebd6b".to_string(), // green
-            mode_visual: "#bf68d9".to_string(), // purple
-            mode_command: "#e2b86b".to_string(),// yellow
+            background: "#181b20".to_string(),   // bg_dark
+            foreground: "#a0a8b7".to_string(),   // fg
+            mode_normal: "#4fa6ed".to_string(),  // blue
+            mode_insert: "#8ebd6b".to_string(),  // green
+            mode_visual: "#bf68d9".to_string(),  // purple
+            mode_command: "#e2b86b".to_string(), // yellow
         }
     }
 }
@@ -526,12 +526,20 @@ impl Theme {
             black,
 
             // UI styles
-            active_border: Style::default().fg(active_border_color).add_modifier(Modifier::BOLD),
+            active_border: Style::default()
+                .fg(active_border_color)
+                .add_modifier(Modifier::BOLD),
             inactive_border: Style::default().fg(inactive_border_color),
-            selected: Style::default().fg(selected_fg).bg(selected_bg).add_modifier(Modifier::BOLD),
+            selected: Style::default()
+                .fg(selected_fg)
+                .bg(selected_bg)
+                .add_modifier(Modifier::BOLD),
             normal: Style::default().fg(fg),
             disabled: Style::default().fg(gray),
-            search_highlight: Style::default().fg(search_match_fg).bg(search_match_bg).add_modifier(Modifier::BOLD),
+            search_highlight: Style::default()
+                .fg(search_match_fg)
+                .bg(search_match_bg)
+                .add_modifier(Modifier::BOLD),
             info: Style::default().fg(cyan),
             success: Style::default().fg(green),
             warning: Style::default().fg(yellow),

--- a/src/directory_store.rs
+++ b/src/directory_store.rs
@@ -1,3 +1,4 @@
+use ignore::WalkBuilder;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{self, BufReader, BufWriter};
@@ -6,7 +7,6 @@ use std::sync::{
     mpsc, Arc, Mutex,
 };
 use std::thread;
-use ignore::WalkBuilder;
 use walkdir::WalkDir;
 
 #[derive(Serialize, Deserialize, Default, Clone, Debug)]
@@ -105,11 +105,7 @@ pub fn build_directory_from_store_ignore(
                 if entry.depth() == 0 {
                     continue; // skip the root itself
                 }
-                if entry
-                    .file_type()
-                    .map(|ft| ft.is_dir())
-                    .unwrap_or(false)
-                {
+                if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
                     if let Some(s) = entry.path().to_str() {
                         store.insert(s);
                     }
@@ -211,11 +207,7 @@ pub fn build_directory_from_store_async(
                         if entry.depth() == 0 {
                             return ignore::WalkState::Continue;
                         }
-                        if entry
-                            .file_type()
-                            .map(|ft| ft.is_dir())
-                            .unwrap_or(false)
-                        {
+                        if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
                             if let Some(s) = entry.path().to_str() {
                                 {
                                     let mut guard = store_arc.lock().unwrap();
@@ -251,7 +243,9 @@ pub fn build_directory_from_store_async(
             let guard = store.lock().unwrap();
             guard.clone()
         };
-        let _ = tx.send(CacheBuildProgress::Completed { store: store_cloned });
+        let _ = tx.send(CacheBuildProgress::Completed {
+            store: store_cloned,
+        });
     });
 
     rx

--- a/src/event/file_actions.rs
+++ b/src/event/file_actions.rs
@@ -1,10 +1,6 @@
 use std::path::{Path, PathBuf};
 
-use crate::{
-    app::App,
-    event::navigation::parent_directory,
-    utils::get_file_path_data,
-};
+use crate::{app::App, event::navigation::parent_directory, utils::get_file_path_data};
 
 pub fn containing_directory(path: &Path) -> PathBuf {
     parent_directory(path).unwrap_or_default()

--- a/src/file_reader_content.rs
+++ b/src/file_reader_content.rs
@@ -8,10 +8,7 @@ use std::{
 
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span, Text};
-use ratatui::{
-    style::Color,
-    widgets::Paragraph,
-};
+use ratatui::{style::Color, widgets::Paragraph};
 
 // Use centralized theme colors for markdown
 use crate::ui::theme::markdown as markdown_colors;
@@ -127,7 +124,9 @@ impl PreviewCache {
     /// Check if a path has a valid cached preview (file hasn't been modified)
     pub fn contains(&self, path: &str) -> bool {
         let current_mtime = fs::metadata(path).ok().and_then(|m| m.modified().ok());
-        self.entries.iter().any(|e| e.path == path && e.modified_time == current_mtime)
+        self.entries
+            .iter()
+            .any(|e| e.path == path && e.modified_time == current_mtime)
     }
 }
 #[derive(Debug, Clone)]
@@ -157,12 +156,10 @@ pub fn detect_file_type(path: &str) -> FileType {
 
             match ext.as_str() {
                 // Source code files
-                "rs" | "py" | "js" | "ts" | "jsx" | "tsx" | "c" | "cpp" | "cc" | "cxx"
-                | "h" | "hpp" | "java" | "go" | "php" | "rb" | "scala" | "kt" | "swift"
-                | "dart" | "css" | "scss" | "less" | "html" | "htm" | "xml" | "vue"
-                | "svelte" | "sql" | "sh" | "bash" | "zsh" | "fish" | "ps1" | "bat" => {
-                    FileType::SourceCode
-                }
+                "rs" | "py" | "js" | "ts" | "jsx" | "tsx" | "c" | "cpp" | "cc" | "cxx" | "h"
+                | "hpp" | "java" | "go" | "php" | "rb" | "scala" | "kt" | "swift" | "dart"
+                | "css" | "scss" | "less" | "html" | "htm" | "xml" | "vue" | "svelte" | "sql"
+                | "sh" | "bash" | "zsh" | "fish" | "ps1" | "bat" => FileType::SourceCode,
 
                 // Markdown and documentation
                 "md" | "markdown" | "rst" | "adoc" | "asciidoc" => FileType::Markdown,
@@ -198,8 +195,8 @@ pub fn detect_file_type(path: &str) -> FileType {
                 "pdf" => FileType::PDF,
 
                 // Binary and executable files
-                "exe" | "dll" | "so" | "dylib" | "bin" | "app" | "deb" | "rpm" | "dmg"
-                | "iso" | "img" | "msi" => FileType::Binary,
+                "exe" | "dll" | "so" | "dylib" | "bin" | "app" | "deb" | "rpm" | "dmg" | "iso"
+                | "img" | "msi" => FileType::Binary,
 
                 _ => detect_file_type_by_content_standalone(path),
             }
@@ -275,7 +272,11 @@ pub fn read_pdf_content_standalone(path: &str) -> String {
                 let preview = preview_lines.join("\n");
 
                 if total_lines > 200 {
-                    format!("{}\n\n... (truncated, {} more lines)", preview, total_lines - 200)
+                    format!(
+                        "{}\n\n... (truncated, {} more lines)",
+                        preview,
+                        total_lines - 200
+                    )
                 } else {
                     preview
                 }
@@ -285,7 +286,8 @@ pub fn read_pdf_content_standalone(path: &str) -> String {
             // Check for common PDF issues
             let error_str = e.to_string();
             if error_str.contains("password") || error_str.contains("encrypted") {
-                "PDF file is password-protected.\n\nUnable to extract text without the password.".to_string()
+                "PDF file is password-protected.\n\nUnable to extract text without the password."
+                    .to_string()
             } else {
                 format!("Unable to read PDF content.\n\nError: {}\n\nTry opening with an external PDF viewer.", e)
             }
@@ -457,7 +459,10 @@ pub fn render_markdown(content: &str) -> Vec<Line<'static>> {
         // Table row
         else if line.contains('|') && line.trim().starts_with('|') {
             // Check if it's a separator row
-            if line.chars().all(|c| c == '|' || c == '-' || c == ':' || c == ' ') {
+            if line
+                .chars()
+                .all(|c| c == '|' || c == '-' || c == ':' || c == ' ')
+            {
                 lines.push(Line::from(Span::styled(
                     line.to_string(),
                     Style::default().fg(markdown_colors::TABLE_BORDER),
@@ -755,7 +760,10 @@ pub fn load_preview_async(
     let file_type = detect_file_type(&path);
 
     // For binary files, don't try to read as text (but PDF and Image are handled specially)
-    if matches!(file_type, FileType::Binary | FileType::ZIP | FileType::Archive) {
+    if matches!(
+        file_type,
+        FileType::Binary | FileType::ZIP | FileType::Archive
+    ) {
         let _ = sender.send(PreviewMessage::Loaded {
             path,
             content: String::new(), // Content will be handled specially in main
@@ -972,7 +980,9 @@ impl FileContent<'_> {
             let mut spans: Vec<Line<'static>> = vec![];
             let syntax_set = self.syntax_set.clone();
             // Use configured theme, fall back to default if not found
-            let theme = self.theme_set.themes
+            let theme = self
+                .theme_set
+                .themes
                 .get(&self.syntax_theme_name)
                 .cloned()
                 .unwrap_or_else(|| self.theme_set.themes["base16-ocean.dark"].clone());
@@ -1352,14 +1362,21 @@ impl FileContent<'_> {
             if let Ok(file) = archive.by_index(i) {
                 if let Some(fil_path) = file.enclosed_name() {
                     let size = file.size();
-                    list.push(format!("{} ({})", fil_path.display(), Self::format_file_size(size)));
+                    list.push(format!(
+                        "{} ({})",
+                        fil_path.display(),
+                        Self::format_file_size(size)
+                    ));
                 }
             }
         }
 
         // Add truncation message if there are more entries
         if total_entries > MAX_ARCHIVE_ENTRIES {
-            list.push(format!("... and {} more entries", total_entries - MAX_ARCHIVE_ENTRIES));
+            list.push(format!(
+                "... and {} more entries",
+                total_entries - MAX_ARCHIVE_ENTRIES
+            ));
         }
 
         self.curr_zip_content = list;
@@ -1464,7 +1481,11 @@ impl FileContent<'_> {
                     let preview = preview_lines.join("\n");
 
                     if total_lines > 200 {
-                        format!("{}\n\n... (truncated, {} more lines)", preview, total_lines - 200)
+                        format!(
+                            "{}\n\n... (truncated, {} more lines)",
+                            preview,
+                            total_lines - 200
+                        )
                     } else {
                         preview
                     }

--- a/src/icons.rs
+++ b/src/icons.rs
@@ -208,7 +208,9 @@ impl IconProvider {
         if let Some(ref name) = filename {
             let icon = match name.as_str() {
                 "dockerfile" | "dockerfile.dev" | "dockerfile.prod" => Some(icons::DOCKERFILE),
-                "docker-compose.yml" | "docker-compose.yaml" | "compose.yml" | "compose.yaml" => Some(icons::DOCKER),
+                "docker-compose.yml" | "docker-compose.yaml" | "compose.yml" | "compose.yaml" => {
+                    Some(icons::DOCKER)
+                }
                 "makefile" | "gnumakefile" => Some(icons::MAKEFILE),
                 "cargo.toml" => Some(icons::RUST),
                 "cargo.lock" => Some(icons::LOCK),
@@ -217,7 +219,9 @@ impl IconProvider {
                 "readme" | "readme.md" | "readme.txt" | "readme.rst" => Some(icons::README),
                 "license" | "license.md" | "license.txt" | "copying" => Some(icons::LICENSE),
                 ".gitignore" | ".gitattributes" | ".gitmodules" => Some(icons::GITIGNORE),
-                ".env" | ".env.local" | ".env.development" | ".env.production" => Some(icons::CONFIG),
+                ".env" | ".env.local" | ".env.development" | ".env.production" => {
+                    Some(icons::CONFIG)
+                }
                 "requirements.txt" | "pyproject.toml" | "setup.py" => Some(icons::PYTHON),
                 "gemfile" | "gemfile.lock" => Some(icons::RUBY),
                 _ => None,
@@ -274,7 +278,12 @@ impl IconProvider {
     }
 
     /// Get colored icon for a file based on its path, using theme colors
-    pub fn get_colored_for_path(&self, path: &Path, is_directory: bool, theme: &ThemeColors) -> ColoredIcon {
+    pub fn get_colored_for_path(
+        &self,
+        path: &Path,
+        is_directory: bool,
+        theme: &ThemeColors,
+    ) -> ColoredIcon {
         let icon = self.get_icon_pair_for_path(path, is_directory);
         let color = Self::get_color_for_path(path, is_directory, theme);
         ColoredIcon::new(icon, color)
@@ -302,7 +311,9 @@ impl IconProvider {
         if let Some(ref name) = filename {
             let color = match name.as_str() {
                 "dockerfile" | "dockerfile.dev" | "dockerfile.prod" => Some(theme.icon_docker),
-                "docker-compose.yml" | "docker-compose.yaml" | "compose.yml" | "compose.yaml" => Some(theme.icon_docker),
+                "docker-compose.yml" | "docker-compose.yaml" | "compose.yml" | "compose.yaml" => {
+                    Some(theme.icon_docker)
+                }
                 "makefile" | "gnumakefile" => Some(theme.icon_config),
                 "cargo.toml" => Some(theme.icon_rust),
                 "cargo.lock" => Some(theme.icon_lock),
@@ -311,7 +322,9 @@ impl IconProvider {
                 "readme" | "readme.md" | "readme.txt" | "readme.rst" => Some(theme.icon_readme),
                 "license" | "license.md" | "license.txt" | "copying" => Some(theme.icon_license),
                 ".gitignore" | ".gitattributes" | ".gitmodules" => Some(theme.icon_git),
-                ".env" | ".env.local" | ".env.development" | ".env.production" => Some(theme.icon_config),
+                ".env" | ".env.local" | ".env.development" | ".env.production" => {
+                    Some(theme.icon_config)
+                }
                 "requirements.txt" | "pyproject.toml" | "setup.py" => Some(theme.icon_python),
                 "gemfile" | "gemfile.lock" => Some(theme.icon_ruby),
                 _ => None,
@@ -350,7 +363,9 @@ impl IconProvider {
             Some("xml" | "plist") => theme.icon_xml,
             Some("md" | "markdown" | "rst") => theme.icon_markdown,
             Some("ini" | "cfg" | "conf" | "config") => theme.icon_config,
-            Some("png" | "jpg" | "jpeg" | "gif" | "bmp" | "svg" | "ico" | "webp") => theme.icon_image,
+            Some("png" | "jpg" | "jpeg" | "gif" | "bmp" | "svg" | "ico" | "webp") => {
+                theme.icon_image
+            }
             Some("mp4" | "avi" | "mkv" | "mov" | "wmv" | "flv" | "webm") => theme.icon_video,
             Some("mp3" | "wav" | "ogg" | "flac" | "aac" | "m4a") => theme.icon_audio,
             Some("pdf") => theme.icon_pdf,

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,10 @@ use std::{
 // External crate imports
 use copypasta::{ClipboardContext, ClipboardProvider};
 use crossterm::{
-    event::{self as crossterm_event, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEventKind},
+    event::{
+        self as crossterm_event, DisableMouseCapture, EnableMouseCapture, Event, KeyCode,
+        KeyEventKind,
+    },
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -40,11 +43,11 @@ mod errors;
 mod event;
 mod file_reader_content;
 mod highlight;
+mod icons;
 mod operations;
 mod pane;
 mod render;
 mod status_bar;
-mod icons;
 mod theme;
 mod ui;
 mod utils;
@@ -616,7 +619,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             let file_type = file_reader_content::detect_file_type(&path);
             let is_cacheable = matches!(
                 file_type,
-                FileType::SourceCode | FileType::ConfigFile | FileType::JSON | FileType::Markdown | FileType::TextFile
+                FileType::SourceCode
+                    | FileType::ConfigFile
+                    | FileType::JSON
+                    | FileType::Markdown
+                    | FileType::TextFile
             );
 
             if is_file_path && is_cacheable && file_reader_content.is_cached(&path) {
@@ -657,7 +664,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Ok(msg) => {
                     use crate::app::PreviewMessage;
                     match msg {
-                        PreviewMessage::Loaded { path, content, file_type, .. } => {
+                        PreviewMessage::Loaded {
+                            path,
+                            content,
+                            file_type,
+                            ..
+                        } => {
                             // Only update if this is still the file we're waiting for
                             if app.preview_loading_path.as_ref() == Some(&path) {
                                 app.preview_loading = false;
@@ -665,16 +677,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                                 // For text-based files, apply syntax highlighting or markdown rendering
                                 match file_type {
-                                    FileType::SourceCode | FileType::ConfigFile | FileType::JSON => {
+                                    FileType::SourceCode
+                                    | FileType::ConfigFile
+                                    | FileType::JSON => {
                                         // Set current path BEFORE calling get_highlighted_content (used for cache lookup)
                                         file_reader_content.curr_selected_path = path.clone();
-                                        let ext_type = file_reader_content.get_file_extension_type(path.clone());
-                                        let highlighted = file_reader_content.get_highlighted_content(content.clone(), ext_type);
+                                        let ext_type = file_reader_content
+                                            .get_file_extension_type(path.clone());
+                                        let highlighted = file_reader_content
+                                            .get_highlighted_content(content.clone(), ext_type);
                                         app.preview_file_content = highlighted;
                                     }
                                     FileType::Markdown => {
                                         // Render markdown with formatting
-                                        file_reader_content.render_markdown_content(&content, &path);
+                                        file_reader_content
+                                            .render_markdown_content(&content, &path);
                                         app.preview_file_content.clear();
                                     }
                                     FileType::Image => {
@@ -690,12 +707,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         // Spawn thread to decode image
                                         let path_for_thread = path;
                                         std::thread::spawn(move || {
-                                            file_reader_content::load_image_async(path_for_thread, img_tx);
+                                            file_reader_content::load_image_async(
+                                                path_for_thread,
+                                                img_tx,
+                                            );
                                         });
                                     }
                                     FileType::Binary => {
                                         file_reader_content.hightlighted_content = None;
-                                        app.preview_file_content = file_reader_content.read_binary_hex_view(&path);
+                                        app.preview_file_content =
+                                            file_reader_content.read_binary_hex_view(&path);
                                     }
                                     FileType::ZIP => {
                                         file_reader_content.hightlighted_content = None;
@@ -715,10 +736,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                             "gz" if path.to_lowercase().ends_with(".tar.gz") => {
                                                 file_reader_content.read_tar_gz_content(&path)
                                             }
-                                            "bz2" | "tbz2" if path.to_lowercase().ends_with(".tar.bz2") => {
+                                            "bz2" | "tbz2"
+                                                if path.to_lowercase().ends_with(".tar.bz2") =>
+                                            {
                                                 file_reader_content.read_tar_bz2_content(&path)
                                             }
-                                            "xz" | "txz" if path.to_lowercase().ends_with(".tar.xz") => {
+                                            "xz" | "txz"
+                                                if path.to_lowercase().ends_with(".tar.xz") =>
+                                            {
                                                 file_reader_content.read_tar_xz_content(&path)
                                             }
                                             _ => vec![format!("Archive preview not supported")],
@@ -1361,8 +1386,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                                     // Calculate selection based on preserved index
                                     let new_len = app.files.len();
-                                    let selected_indx =
-                                        app.preserved_selection_index.unwrap_or(0);
+                                    let selected_indx = app.preserved_selection_index.unwrap_or(0);
                                     let next_selection_index = if new_len == 0 {
                                         None
                                     } else if selected_indx >= new_len {
@@ -1694,7 +1718,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                         } else {
                                             // For files, get the file size (fast operation)
                                             app.delete_target_file_count = None;
-                                            app.delete_target_total_size = path.metadata().ok().map(|m| m.len());
+                                            app.delete_target_total_size =
+                                                path.metadata().ok().map(|m| m.len());
                                         }
                                     }
                                 }
@@ -2149,7 +2174,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                     if path.is_dir() {
                                         // For directories, use async delete with progress
                                         app.delete_in_progress = true;
-                                        app.delete_progress_message = "Counting files...".to_string();
+                                        app.delete_progress_message =
+                                            "Counting files...".to_string();
                                         app.preserved_selection_index = Some(selected_indx);
                                         delete_target_dir = Some(current_dir);
                                         delete_receiver = Some(delete_with_progress(selected));

--- a/src/operations/copy.rs
+++ b/src/operations/copy.rs
@@ -395,7 +395,8 @@ pub fn copy_dir_file_with_progress(src: &Path, new_src: &Path) -> mpsc::Receiver
 
                         // Track bytes copied (get file size)
                         let file_size = entry_path.metadata().map(|m| m.len()).unwrap_or(0);
-                        let current_bytes = bytes_copied.fetch_add(file_size, Ordering::Relaxed) + file_size;
+                        let current_bytes =
+                            bytes_copied.fetch_add(file_size, Ordering::Relaxed) + file_size;
 
                         let count = processed.fetch_add(1, Ordering::Relaxed) + 1;
                         if count % UPDATE_INTERVAL == 0 || count == total_files {

--- a/src/operations/file_ops.rs
+++ b/src/operations/file_ops.rs
@@ -116,7 +116,8 @@ pub fn delete_with_progress(file_path: &str) -> mpsc::Receiver<DeleteMessage> {
 
         if src.is_file() {
             // Single file delete - quick operation
-            let file_name = src.file_name()
+            let file_name = src
+                .file_name()
                 .unwrap_or_default()
                 .to_string_lossy()
                 .to_string();
@@ -155,7 +156,9 @@ pub fn delete_with_progress(file_path: &str) -> mpsc::Receiver<DeleteMessage> {
                 .collect();
 
             file_count = entries.len();
-            let _ = tx.send(DeleteMessage::Counting { files_counted: file_count });
+            let _ = tx.send(DeleteMessage::Counting {
+                files_counted: file_count,
+            });
 
             // Sort by depth (deepest first) so we delete children before parents
             let mut paths: Vec<_> = entries.iter().map(|e| e.path().to_path_buf()).collect();
@@ -312,9 +315,10 @@ pub fn move_file_or_dir(src_path: &str, dest_dir: &str) -> FileOperationResult<(
                 Ok(())
             } else {
                 Err(match e.kind() {
-                    io::ErrorKind::PermissionDenied => {
-                        FileOperationError::permission_denied(src, "Cannot move - check permissions")
-                    }
+                    io::ErrorKind::PermissionDenied => FileOperationError::permission_denied(
+                        src,
+                        "Cannot move - check permissions",
+                    ),
                     io::ErrorKind::NotFound => FileOperationError::file_not_found(src),
                     io::ErrorKind::AlreadyExists => FileOperationError::already_exists(&dest),
                     _ => FileOperationError::from(e),

--- a/src/pane.rs
+++ b/src/pane.rs
@@ -139,9 +139,9 @@ impl Pane {
         self.selected_index.and_then(|idx| {
             if !self.search_results.is_empty() {
                 // In search mode, use filtered indexes
-                self.filtered_indexes.get(idx).and_then(|&real_idx| {
-                    self.files.get(real_idx).cloned()
-                })
+                self.filtered_indexes
+                    .get(idx)
+                    .and_then(|&real_idx| self.files.get(real_idx).cloned())
             } else {
                 self.files.get(idx).cloned()
             }
@@ -166,7 +166,11 @@ impl Pane {
 
         let new_index = match self.selected_index {
             Some(i) => {
-                if i >= list_len - 1 { 0 } else { i + 1 }
+                if i >= list_len - 1 {
+                    0
+                } else {
+                    i + 1
+                }
             }
             None => 0,
         };
@@ -184,7 +188,11 @@ impl Pane {
 
         let new_index = match self.selected_index {
             Some(i) => {
-                if i == 0 { list_len - 1 } else { i - 1 }
+                if i == 0 {
+                    list_len - 1
+                } else {
+                    i - 1
+                }
             }
             None => 0,
         };
@@ -355,10 +363,16 @@ mod tests {
         ];
         let mut pane = Pane::new("/home/user".to_string(), files);
 
-        assert_eq!(pane.get_selected_path(), Some("/home/user/a.txt".to_string()));
+        assert_eq!(
+            pane.get_selected_path(),
+            Some("/home/user/a.txt".to_string())
+        );
 
         pane.navigate_down();
-        assert_eq!(pane.get_selected_path(), Some("/home/user/b.txt".to_string()));
+        assert_eq!(
+            pane.get_selected_path(),
+            Some("/home/user/b.txt".to_string())
+        );
     }
 
     #[test]

--- a/src/render/popups.rs
+++ b/src/render/popups.rs
@@ -141,7 +141,12 @@ pub fn create_create_input_popup<'a>(
     };
 
     Paragraph::new(input_text)
-        .block(Block::default().borders(Borders::ALL).border_set(border::ROUNDED).title(title))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_set(border::ROUNDED)
+                .title(title),
+        )
         .style(style)
 }
 

--- a/src/render/preview.rs
+++ b/src/render/preview.rs
@@ -18,7 +18,11 @@ pub fn create_file_preview<'a>(content: &'a str) -> Paragraph<'a> {
 pub fn create_image_preview<'a>(image_info: &'a str, has_image: bool) -> Paragraph<'a> {
     if has_image {
         Paragraph::new(image_info)
-            .block(Block::default().borders(Borders::ALL).title("Image Preview"))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .title("Image Preview"),
+            )
             .style(Style::default().fg(Color::Green))
     } else {
         let display_text = if image_info.is_empty() {

--- a/src/status_bar.rs
+++ b/src/status_bar.rs
@@ -206,7 +206,11 @@ impl StatusBar {
         // Mode indicator with rounded borders
         let (mode_text, mode_color) = Self::get_mode_indicator(&app.input_mode, theme);
         let mode_widget = Paragraph::new(mode_text)
-            .block(Block::default().borders(Borders::ALL).border_set(border::ROUNDED))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_set(border::ROUNDED),
+            )
             .style(Style::default().fg(mode_color).add_modifier(Modifier::BOLD))
             .alignment(Alignment::Center);
         frame.render_widget(mode_widget, chunks[0]);
@@ -214,7 +218,12 @@ impl StatusBar {
         // View mode indicator
         let (view_text, view_color) = Self::get_view_mode_indicator(&app.view_mode, theme);
         let view_widget = Paragraph::new(view_text)
-            .block(Block::default().borders(Borders::ALL).border_set(border::ROUNDED).title("View"))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_set(border::ROUNDED)
+                    .title("View"),
+            )
             .style(Style::default().fg(view_color))
             .alignment(Alignment::Center);
         frame.render_widget(view_widget, chunks[1]);
@@ -225,14 +234,24 @@ impl StatusBar {
         let dir_text = format_path_for_display(&self.current_directory, available_width);
 
         let dir_widget = Paragraph::new(dir_text)
-            .block(Block::default().borders(Borders::ALL).border_set(border::ROUNDED).title("Directory"))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_set(border::ROUNDED)
+                    .title("Directory"),
+            )
             .style(Style::default().fg(theme.fg));
         frame.render_widget(dir_widget, chunks[2]);
 
         // File and directory counts
         let counts_text = format!("{}F {}D", self.file_count, self.directory_count);
         let counts_widget = Paragraph::new(counts_text)
-            .block(Block::default().borders(Borders::ALL).border_set(border::ROUNDED).title("Items"))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_set(border::ROUNDED)
+                    .title("Items"),
+            )
             .style(Style::default().fg(theme.cyan))
             .alignment(Alignment::Center);
         frame.render_widget(counts_widget, chunks[3]);
@@ -240,14 +259,24 @@ impl StatusBar {
         // Total size
         let size_text = Self::format_file_size(self.total_size);
         let size_widget = Paragraph::new(size_text)
-            .block(Block::default().borders(Borders::ALL).border_set(border::ROUNDED).title("Size"))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_set(border::ROUNDED)
+                    .title("Size"),
+            )
             .style(Style::default().fg(theme.yellow))
             .alignment(Alignment::Center);
         frame.render_widget(size_widget, chunks[4]);
 
         // System info
         let system_widget = Paragraph::new(self.system_info.clone())
-            .block(Block::default().borders(Borders::ALL).border_set(border::ROUNDED).title("System"))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_set(border::ROUNDED)
+                    .title("System"),
+            )
             .style(Style::default().fg(theme.gray))
             .alignment(Alignment::Center);
         frame.render_widget(system_widget, chunks[5]);
@@ -296,7 +325,10 @@ impl StatusBar {
     }
 
     /// Get short mode indicator for minimal status bar
-    fn get_mode_indicator_short(input_mode: &InputMode, theme: &ThemeColors) -> (&'static str, Color) {
+    fn get_mode_indicator_short(
+        input_mode: &InputMode,
+        theme: &ThemeColors,
+    ) -> (&'static str, Color) {
         match input_mode {
             InputMode::Normal => ("NOR", theme.green),
             InputMode::Editing => ("SRC", theme.blue),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -370,7 +370,9 @@ impl Ui {
                     let file_path = &app.files[file_index];
                     let path = Path::new(file_path);
                     let is_dir = path.is_dir();
-                    let colored_icon = self.icon_provider.get_colored_for_path(path, is_dir, &app.theme_colors);
+                    let colored_icon =
+                        self.icon_provider
+                            .get_colored_for_path(path, is_dir, &app.theme_colors);
 
                     if app.input_mode == InputMode::Editing && !search_term.is_empty() {
                         // Local search with highlighting

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -10,24 +10,24 @@ pub mod palette {
     use ratatui::style::Color;
 
     // Core colors
-    pub const RED: Color = Color::Rgb(229, 85, 97);        // #e55561
-    pub const GREEN: Color = Color::Rgb(142, 189, 107);    // #8ebd6b
-    pub const YELLOW: Color = Color::Rgb(226, 184, 107);   // #e2b86b
-    pub const BLUE: Color = Color::Rgb(79, 166, 237);      // #4fa6ed
-    pub const PURPLE: Color = Color::Rgb(191, 104, 217);   // #bf68d9
-    pub const CYAN: Color = Color::Rgb(72, 176, 189);      // #48b0bd
-    pub const ORANGE: Color = Color::Rgb(204, 144, 87);    // #cc9057
+    pub const RED: Color = Color::Rgb(229, 85, 97); // #e55561
+    pub const GREEN: Color = Color::Rgb(142, 189, 107); // #8ebd6b
+    pub const YELLOW: Color = Color::Rgb(226, 184, 107); // #e2b86b
+    pub const BLUE: Color = Color::Rgb(79, 166, 237); // #4fa6ed
+    pub const PURPLE: Color = Color::Rgb(191, 104, 217); // #bf68d9
+    pub const CYAN: Color = Color::Rgb(72, 176, 189); // #48b0bd
+    pub const ORANGE: Color = Color::Rgb(204, 144, 87); // #cc9057
 
     // Grayscale
-    pub const GRAY: Color = Color::Rgb(83, 89, 101);       // #535965
+    pub const GRAY: Color = Color::Rgb(83, 89, 101); // #535965
     pub const LIGHT_GRAY: Color = Color::Rgb(122, 129, 142); // #7a818e
-    pub const FG: Color = Color::Rgb(160, 168, 183);       // #a0a8b7
-    pub const BG: Color = Color::Rgb(31, 35, 41);          // #1f2329
-    pub const BG_DARK: Color = Color::Rgb(24, 27, 32);     // #181b20
-    pub const BG_LIGHTER: Color = Color::Rgb(40, 44, 52);  // #282c34
+    pub const FG: Color = Color::Rgb(160, 168, 183); // #a0a8b7
+    pub const BG: Color = Color::Rgb(31, 35, 41); // #1f2329
+    pub const BG_DARK: Color = Color::Rgb(24, 27, 32); // #181b20
+    pub const BG_LIGHTER: Color = Color::Rgb(40, 44, 52); // #282c34
     pub const BG_HIGHLIGHT: Color = Color::Rgb(48, 54, 63); // #30363f
-    pub const SELECTION: Color = Color::Rgb(50, 54, 65);   // #323641
-    pub const BLACK: Color = Color::Rgb(14, 16, 19);       // #0e1013
+    pub const SELECTION: Color = Color::Rgb(50, 54, 65); // #323641
+    pub const BLACK: Color = Color::Rgb(14, 16, 19); // #0e1013
 }
 
 /// UI element styles
@@ -182,7 +182,7 @@ pub mod icons {
     pub const DIRECTORY: Color = palette::BLUE;
 
     // Programming languages - use language brand colors where appropriate
-    pub const RUST: Color = Color::Rgb(222, 165, 132);      // Rust orange
+    pub const RUST: Color = Color::Rgb(222, 165, 132); // Rust orange
     pub const JAVASCRIPT: Color = palette::YELLOW;
     pub const TYPESCRIPT: Color = palette::BLUE;
     pub const PYTHON: Color = palette::BLUE;

--- a/src/utils/format.rs
+++ b/src/utils/format.rs
@@ -204,7 +204,13 @@ pub fn format_path_for_display(path: &str, max_width: usize) -> String {
     if result_parts.is_empty() {
         format!("{}{}{}", prefix, sep, last_segment)
     } else {
-        format!("{}{}{}/{}", prefix, sep, result_parts.join("/"), last_segment)
+        format!(
+            "{}{}{}/{}",
+            prefix,
+            sep,
+            result_parts.join("/"),
+            last_segment
+        )
     }
 }
 
@@ -305,9 +311,17 @@ mod tests {
         // Should fit within width
         assert!(result.len() <= 30, "Result '{}' exceeds 30 chars", result);
         // Should preserve last segment
-        assert!(result.ends_with("render"), "Result '{}' doesn't end with 'render'", result);
+        assert!(
+            result.ends_with("render"),
+            "Result '{}' doesn't end with 'render'",
+            result
+        );
         // Should start with ~/
-        assert!(result.starts_with("~/"), "Result '{}' doesn't start with ~/", result);
+        assert!(
+            result.starts_with("~/"),
+            "Result '{}' doesn't start with ~/",
+            result
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Apply `cargo fmt` across the existing Rust source and example files.
- Establish a clean `cargo fmt --check` baseline for future CI/foundation work.
- No behavior changes intended; this is mechanical formatting only.

## Test Plan
- [x] cargo fmt --check
- [x] cargo check --all-targets --quiet
- [x] cargo test --quiet
- [x] No manual test needed; formatting-only change