### PR TITLE
fix: root search responsiveness

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Instant;
@@ -147,6 +148,22 @@ fn truncate_top_search_results(search_results: &mut Vec<SearchResult>, max_resul
     }
 
     search_results.sort_unstable_by(search_result_order);
+    search_results.truncate(max_results);
+}
+
+fn deduplicate_sorted_search_results(search_results: &mut Vec<SearchResult>) {
+    let mut seen_paths = HashSet::new();
+    search_results.retain(|result| seen_paths.insert(result.file_path.clone()));
+}
+
+fn truncate_top_unique_search_results(search_results: &mut Vec<SearchResult>, max_results: usize) {
+    if max_results == 0 {
+        search_results.clear();
+        return;
+    }
+
+    search_results.sort_unstable_by(search_result_order);
+    deduplicate_sorted_search_results(search_results);
     search_results.truncate(max_results);
 }
 
@@ -498,10 +515,14 @@ impl App {
     }
 
     pub fn enter_char(&mut self, new_char: char, store: DirectoryStore) {
-        let index = self.byte_index();
-        self.input.insert(index, new_char);
+        self.insert_char_without_filter(new_char);
         self.filter_files(self.input.clone(), store);
         self.move_cursor_right();
+    }
+
+    pub fn insert_char_without_filter(&mut self, new_char: char) {
+        let index = self.byte_index();
+        self.input.insert(index, new_char);
     }
 
     pub fn enter_search(&mut self, scope: SearchScope) {
@@ -614,7 +635,7 @@ impl App {
                 left
             });
 
-        truncate_top_search_results(&mut search_results, max_results);
+        truncate_top_unique_search_results(&mut search_results, max_results);
         apply_short_unique_display_names(&mut search_results);
 
         // For global search, we don't use filtered_indexes since we're showing different files
@@ -631,6 +652,12 @@ impl App {
     }
 
     pub fn delete_char(&mut self, store: DirectoryStore) {
+        if self.delete_char_without_filter() {
+            self.filter_files(self.input.clone(), store);
+        }
+    }
+
+    pub fn delete_char_without_filter(&mut self) -> bool {
         let is_not_cursor_leftmost = self.character_index != 0;
         if is_not_cursor_leftmost {
             let current_index = self.character_index;
@@ -641,9 +668,11 @@ impl App {
             let after_char_to_delete = self.input.chars().skip(current_index);
 
             self.input = before_char_to_delete.chain(after_char_to_delete).collect();
-            self.filter_files(self.input.clone(), store);
             self.move_cursor_left();
+            return true;
         }
+
+        false
     }
 
     pub fn clamp_cursor(&mut self, new_cursor_pos: usize) -> usize {

--- a/src/event/search.rs
+++ b/src/event/search.rs
@@ -1,18 +1,40 @@
 use crossterm::event::KeyCode;
 
 use crate::{
-    app::{App, InputMode},
+    app::{App, InputMode, SearchScope},
     directory_store::DirectoryStore,
 };
+
+fn refresh_root_search(app: &mut App, store: &DirectoryStore) {
+    let query = app.input.trim().to_string();
+    if query.is_empty() {
+        app.search_results.clear();
+        app.filtered_indexes.clear();
+    } else {
+        app.perform_global_search(&query, store);
+    }
+}
 
 pub fn handle_search_key(app: &mut App, key_code: KeyCode, store: &DirectoryStore) {
     match key_code {
         KeyCode::Enter => app.submit_message(),
         KeyCode::Char(to_insert) => {
-            app.enter_char(to_insert, store.clone());
+            if app.search_scope == SearchScope::Root {
+                app.insert_char_without_filter(to_insert);
+                app.move_cursor_right();
+                refresh_root_search(app, store);
+            } else {
+                app.enter_char(to_insert, store.clone());
+            }
         }
         KeyCode::Backspace => {
-            app.delete_char(store.clone());
+            if app.search_scope == SearchScope::Root {
+                if app.delete_char_without_filter() {
+                    refresh_root_search(app, store);
+                }
+            } else {
+                app.delete_char(store.clone());
+            }
         }
         KeyCode::Left => {
             app.move_cursor_left();
@@ -24,5 +46,24 @@ pub fn handle_search_key(app: &mut App, key_code: KeyCode, store: &DirectoryStor
             app.input_mode = InputMode::Normal;
         }
         _ => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_search_key_updates_results_immediately() {
+        let mut app = App::new(Vec::new());
+        let mut store = DirectoryStore::new();
+        store.insert("/workspace/project/src");
+
+        app.enter_search(SearchScope::Root);
+        handle_search_key(&mut app, KeyCode::Char('s'), &store);
+
+        assert_eq!(app.input, "s");
+        assert_eq!(app.search_results.len(), 1);
+        assert_eq!(app.search_results[0].file_path, "/workspace/project/src");
     }
 }

--- a/tests/app_tests.rs
+++ b/tests/app_tests.rs
@@ -374,6 +374,51 @@ mod filtering_tests {
             ]
         );
     }
+
+    #[test]
+    fn root_search_deduplicates_exact_cache_paths() {
+        let mut app = App::new(Vec::new());
+
+        let mut store = DirectoryStore::new();
+        store.insert("/workspace/project/src");
+        store.insert("/workspace/project/src");
+        store.insert("/workspace/other/src");
+
+        app.enter_search(SearchScope::Root);
+        app.filter_files("src".to_string(), store);
+
+        let result_paths: Vec<&str> = app
+            .search_results
+            .iter()
+            .map(|result| result.file_path.as_str())
+            .collect();
+
+        assert_eq!(
+            result_paths,
+            vec!["/workspace/other/src", "/workspace/project/src"]
+        );
+    }
+
+    #[test]
+    fn root_search_prefers_filename_match_before_path_only_match_when_truncating() {
+        let mut app = App::new(Vec::new());
+        app.max_search_results = 1;
+
+        let mut store = DirectoryStore::new();
+        store.insert("/workspace/src/src/src/src/noise");
+        store.insert("/workspace/project/src");
+
+        app.enter_search(SearchScope::Root);
+        app.filter_files("src".to_string(), store);
+
+        let result_paths: Vec<&str> = app
+            .search_results
+            .iter()
+            .map(|result| result.file_path.as_str())
+            .collect();
+
+        assert_eq!(result_paths, vec!["/workspace/project/src"]);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Summary:
- Update root search key handling so results refresh immediately on input without cloning the directory store.
- Keep exact duplicate path cleanup while moving dedupe out of the repeated hot trimming path.
- Add regression coverage for immediate root search updates and global result quality.

Tests:
- cargo test --quiet